### PR TITLE
reorder head tags

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -14,8 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" href="/css/styles.css" />
-  <link rel="shortcut icon" type="image/png" href="https://assets.ubuntu.com/v1/d53eeeac-MicroK8s_favicon_64px_v2.png">
+  
   <title>
     {% if page.title %}
     {{ page.title }} | MicroK8s
@@ -23,9 +22,6 @@
     MicroK8s - Fast, Light, Upstream Developer Kubernetes
     {% endif %}
   </title>
-
-  <!-- GitHub buttons - https://buttons.github.io/ -->
-  <script async defer src="https://buttons.github.io/buttons.js"></script>
 
   <!-- Google Analytics and Google Optimize -->
   <script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -52,6 +48,11 @@
           'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
     })(window, document, 'script', 'dataLayer', 'GTM-T5SMPTS');</script>
   <!-- End Google Tag Manager -->
+  <link rel="stylesheet" href="/css/styles.css" />
+  <link rel="shortcut icon" type="image/png" href="https://assets.ubuntu.com/v1/d53eeeac-MicroK8s_favicon_64px_v2.png">
+
+  <!-- GitHub buttons - https://buttons.github.io/ -->
+  <script async defer src="https://buttons.github.io/buttons.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Done

- Reordered head tags according to Harry R's best practice guidelines

## QA
- See that the head tags are in an order that complies with this list:
```
<meta charset
<meta name=”viewport”
<meta https-equiv=”Accept-CH” content=”DPR, Viewport-Width, Width”>
<title
<preconnect / dns-prefetch
<script> inline
<link rel=”stylesheet”
<styles>Inline styles
Preload - chrome bug - makes it too important - perhaps don’t use it
<script src=”” - external scripts
prefetch/prerender
All the rest - icons, opengraph, etc..
```