### PR TITLE
remove trailing slashes from /docs/ sub pages

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -77,7 +77,7 @@
         </span>
         <ul class="p-navigation__links" role="menu">
           <li class="p-navigation__link {% if page.layout == 'docs' %}is-selected{% endif %}" role="menuitem">
-            <a href="/docs">Docs</a>
+            <a href="/docs/">Docs</a>
           </li>
           <li class="p-navigation__link" role="menuitem">
             <a class="p-link--external" href="https://discuss.kubernetes.io/tags/microk8s">Discourse</a>

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -1,6 +1,7 @@
 ---
 layout: docs
 title: "Multi-node MicroK8s"
+permalink: /docs/clustering
 ---
 # Multi-node MicroK8s
 

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -1,6 +1,7 @@
 ---
 layout: docs
 title: "Services exposed - Authorization and authentication"
+permalink: /docs/ports
 ---
 # Services exposed and ports used
 

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -1,6 +1,7 @@
 ---
 layout: docs
 title: "Release channels and upgrades"
+permalink: /docs/release-channels
 ---
 # Release channels and upgrades
 

--- a/docs/working.md
+++ b/docs/working.md
@@ -1,6 +1,7 @@
 ---
 layout: docs
 title: "Working with image registries"
+permalink: /docs/working
 ---
 # Working with image registries
 

--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@ layout: base
           Working with MicroK8s
         </h2>
         <p class="p-heading--four">
-          Or dive right into the <a href="/docs">docs</a>.
+          Or dive right into the <a href="/docs/">docs</a>.
         </p>
         <div class="asciinema-container"></div>
       </div>


### PR DESCRIPTION
## Done

- Set permalink frontmatter for pages within `/docs` directory, to prevent a redirect
- The same didn't seem to be possible for `/docs/index.html` (open to suggestions if there's a way), so changed links to `/docs` to `/docs/`

## QA

- Visit http://0.0.0.0:8027/
- Open the network panel in dev tools
- Click "docs" in the top nav, and see that you are taken to `/docs/` without a 301 redirect
- On the docs page, click any of the links in the side nav and see that you are taken to the target page without a 301 redirect