### PR TITLE
increase site speed analytics sampling

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -28,7 +28,7 @@
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-1018242-59', 'auto', {'allowLinker': true});
+  ga('create', 'UA-1018242-59', 'auto', {'allowLinker': true, 'siteSpeedSampleRate': 100});
   ga('require', 'GTM-WVQJJBD');
   ga('require', 'linker');
   ga('linker:autoLink', ['conjure-up.io', 'login.ubuntu.com', 'www.ubuntu.com',


### PR DESCRIPTION
## Done

Added `'siteSpeedSampleRate': 100` to GA tag

## QA
- Visit http://0.0.0.0:8027
- Inspect the page source, and see that `'siteSpeedSampleRate': 100` is present in the GA tag
