### PR TITLE
Remove capital letter from command

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@ layout: base
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>
-            Running <code>snap info microK8s</code> shows the current published k8s versions. It is possible to select a specific version like 1.6 and get only stable or RC updates to that version. By default, you will get the current major version with upgrades when new major versions are published.
+            Running <code>snap info microk8s</code> shows the current published k8s versions. It is possible to select a specific version like 1.6 and get only stable or RC updates to that version. By default, you will get the current major version with upgrades when new major versions are published.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Remove capital letter from `snap info microk8s` command

## QA

- Visit http://0.0.0.0:8027/
- Make sure there are no capital letters in the `snap info microk8s`

## Issue / Card
- Fixes #122 