### PR TITLE
Pointing to the right refresh scheduling location

### DIFF
--- a/docs/setting-snap-channel.md
+++ b/docs/setting-snap-channel.md
@@ -196,7 +196,7 @@ all snaps on the system. These are outlined in the
 
 
 <!-- LINKS -->
-[snap-docs]: https://snapcraft.io/docs/system-options
+[snap-docs]:  https://snapcraft.io/docs/keeping-snaps-up-to-date#heading--controlling-updates 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">


### PR DESCRIPTION
Point users to the location on refresh scheduling rather than the generic options setting. 