### PR TITLE
Add KubeCon19 banner

### DIFF
--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -37,7 +37,7 @@
       .p-navigation__logo {
         font-weight: 400;
         margin-right: 0;
-        
+
       }
 
       .p-navigation__toggle {
@@ -47,7 +47,7 @@
         }
       }
     }
-    
+
     .p-navigation__link a {
       height: 100%;
       padding-left: $sph-inner--large ;
@@ -84,8 +84,14 @@
 
 .u-stepped-list-margin{
   margin-left: 3.5rem;
-  
+
   @media only screen and (max-width: $breakpoint-x-small) {
     margin-left: 3rem;
   }
+}
+
+// XXX Steve: 21.06.18
+// https://github.com/vanilla-framework/vanilla-framework/issues/1794
+.u-no-max-width {
+  max-width: none !important;
 }

--- a/index.html
+++ b/index.html
@@ -1,65 +1,80 @@
 ---
 layout: base
 ---
-  <main id="main-content">
-    <section class="p-strip--header is-dark">
-      <div class="row u-vertically-center u-equal-height">
-        <div class="col-8">
-          <h1>Zero-ops Kubernetes for workstations and edge / IoT</h1>
-          
-          <p class="p-heading--four u-sv3">A single package of k8s for 42 flavours of Linux. Made for developers, and great for edge, IoT and appliances.</p>
-          
-          <p><a class="p-button--positive is-inline" href="#get-started">Get started</a>&nbsp;&nbsp;for Linux, Windows or macOS</p>
+<main id="main-content">
+  <section class="p-strip--header is-dark">
+    <div class="row u-vertically-center u-equal-height">
+      <div class="col-8">
+        <h1>Zero-ops Kubernetes for workstations and edge / IoT</h1>
 
-          <div>
-            <a class="github-button" data-size="large" href="https://github.com/ubuntu/microk8s" aria-label="Follow @ubuntu on GitHub"></a>
-            <a class="github-button" data-size="large" href="https://github.com/ubuntu/microk8s" data-icon="octicon-star" data-show-count="true" aria-label="Star ubuntu/microk8s on GitHub"></a>
-            <a class="github-button" data-size="large" href="https://github.com/ubuntu/microk8s/fork" data-icon="octicon-repo-forked" data-show-count="true" aria-label="Fork ubuntu/microk8s on GitHub"></a>
-          </div>
-        </div>
+        <p class="p-heading--four u-sv3">A single package of k8s for 42 flavours of Linux. Made for developers, and great for edge, IoT and appliances.</p>
 
-        <div class="col-4 u-align--center u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/4b663a6c-certified-kubernetes-logo.svg" width="150" alt="Certified Kubernetes" />
+        <p><a class="p-button--positive is-inline" href="#get-started">Get started</a>&nbsp;&nbsp;for Linux, Windows or macOS</p>
+
+        <div>
+          <a class="github-button" data-size="large" href="https://github.com/ubuntu/microk8s" aria-label="Follow @ubuntu on GitHub"></a>
+          <a class="github-button" data-size="large" href="https://github.com/ubuntu/microk8s" data-icon="octicon-star" data-show-count="true" aria-label="Star ubuntu/microk8s on GitHub"></a>
+          <a class="github-button" data-size="large" href="https://github.com/ubuntu/microk8s/fork" data-icon="octicon-repo-forked" data-show-count="true" aria-label="Fork ubuntu/microk8s on GitHub"></a>
         </div>
       </div>
-    </section>
 
-    <section class="p-strip">
-      <div class="row">
-        <div class="col-6">
-          <blockquote  class="p-pull-quote">
-            <p class="p-pull-quote__quote">Canonical might have assembled the easiest way to provision a single node Kubernetes cluster</p>
-
-            <cite class="p-pull-quote__citation">&mdash; <a class="p-link--external" href="https://twitter.com/kelseyhightower/status/1120834594138406912">Kelsey Hightower</a></cite>
-          </blockquote>
-        </div>
-
-        <div class="col-6">
-          <blockquote class="p-pull-quote">
-            <p class="p-pull-quote__quote">dear microk8s team: you are awesome. Microk8s has tangibly improved my life and my CI pipelines as a developer of k8s controllers</p>
-            
-            <cite class="p-pull-quote__citation">&mdash; in <a href="https://kubernetes.slack.com/messages/microk8s/" class=" p-link--external">#microk8s</a></cite>
-          </blockquote>
-        </div>
+      <div class="col-4 u-align--center u-hide--small">
+        <img src="https://assets.ubuntu.com/v1/4b663a6c-certified-kubernetes-logo.svg" width="150" alt="Certified Kubernetes" />
       </div>
-    </section>
+    </div>
+  </section>
 
-    <section class="p-strip--light">
-      <div class="row u-equal-height">
-        <div class="col-3">
-          <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Conformant</li>
-            <li class="p-list__item is-ticked">Istio</li>
-            <li class="p-list__item is-ticked">Storage</li>
-            <li class="p-list__item is-ticked">Clustering <small class="p-label--in-progress">BETA</small></li>
-          </ul>
-        </div>
+  <section class="p-strip--light is-shallow">
+    <div class="row u-equal-height">
+      <div class="col-2 u-vertically-center">
+        <img class="u-hide--small u-no-margin--bottom" style="height: 50px; margin-bottom: .95rem;" src="https://portworx.com/wp-content/uploads/2017/02/kubecon-logo.png" height="50" alt="">
+      </div>
+      <div class="col-10 u-vertically-center">
+        <h4 class="u-no-max-width u-no-margin--bottom">
+          <a class="p-link--external" href="https://ubuntu.com/blog/ubuntu-kubecon-americas-2019">
+            Visit the Ubuntu booth (P36) at Kubecon’19 to win a MicroK8s t-shirt
+          </a>
+        </h4>
+      </div>
+    </div>
+  </section>
 
-        <div class="col-3">
-          <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Registry</li>
-            <li class="p-list__item is-ticked">GPGPU bindings</li>
-            <li class="p-list__item is-ticked">Dashboard</li>
+  <section class="p-strip">
+    <div class="row">
+      <div class="col-6">
+        <blockquote  class="p-pull-quote">
+          <p class="p-pull-quote__quote">Canonical might have assembled the easiest way to provision a single node Kubernetes cluster</p>
+
+          <cite class="p-pull-quote__citation">&mdash; <a class="p-link--external" href="https://twitter.com/kelseyhightower/status/1120834594138406912">Kelsey Hightower</a></cite>
+        </blockquote>
+      </div>
+
+      <div class="col-6">
+        <blockquote class="p-pull-quote">
+          <p class="p-pull-quote__quote">dear microk8s team: you are awesome. Microk8s has tangibly improved my life and my CI pipelines as a developer of k8s controllers</p>
+
+          <cite class="p-pull-quote__citation">&mdash; in <a href="https://kubernetes.slack.com/messages/microk8s/" class=" p-link--external">#microk8s</a></cite>
+        </blockquote>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip--light">
+    <div class="row u-equal-height">
+      <div class="col-3">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Conformant</li>
+          <li class="p-list__item is-ticked">Istio</li>
+          <li class="p-list__item is-ticked">Storage</li>
+          <li class="p-list__item is-ticked">Clustering <small class="p-label--in-progress">BETA</small></li>
+        </ul>
+      </div>
+
+      <div class="col-3">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Registry</li>
+          <li class="p-list__item is-ticked">GPGPU bindings</li>
+          <li class="p-list__item is-ticked">Dashboard</li>
           <li class="p-list__item is-ticked">Metrics</li></ul>
         </div>
 
@@ -209,31 +224,31 @@ layout: base
           <ol class="p-stepped-list u-no-margin--left">
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Install the microk8s snap</h3>
-              
+
               <div class="p-code-copyable u-stepped-list-margin">
                 <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic" value="sudo snap install microk8s --classic" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
-              
+
               <p class="p-stepped-list__content u-stepped-list-margin">Don’t have the <code>snap</code> command? <a href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get set up for snaps.</a></p>
             </li>
-          
+
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Turn on standard services</h3>
-              
+
               <div class="p-code-copyable u-stepped-list-margin">
                 <input class="p-code-copyable__input" aria-label="microk8s.enable dashboard registry istio [...]" value="microk8s.enable dashboard registry istio [...]" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
-              
+
               <p class="p-stepped-list__content u-stepped-list-margin">
                 Similarly, <code>microk8s.disable</code> turns off a service. Try <code>microk8s.enable --help</code> for a list of available services built in.
               </p>
             </li>
-          
+
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Start Kubernetes</h3>
-              
+
               <div class="p-code-copyable u-stepped-list-margin">
                 <input class="p-code-copyable__input" aria-label="sudo microk8s.start" value="sudo microk8s.start" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
@@ -246,7 +261,7 @@ layout: base
           <ol class="p-stepped-list u-no-margin--left">
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Install Multipass for Windows</h3>
-              
+
               <p class="p-stepped-list__content u-stepped-list-margin">
                 <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--positive js-download" data-os="win-win">
                   <span class="p-link--external">Download Multipass for Windows</span>
@@ -256,7 +271,7 @@ layout: base
 
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Launch a Multipass instance</h3>
-              
+
               <div class="p-code-copyable u-stepped-list-margin">
                 <input class="p-code-copyable__input" value="multipass launch --name foo" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
@@ -265,31 +280,31 @@ layout: base
 
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Install the microk8s snap</h3>
-              
+
               <div class="p-code-copyable u-stepped-list-margin">
                 <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic" value="sudo snap install microk8s --classic" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
-              
+
               <p class="p-stepped-list__content u-stepped-list-margin">Don’t have the <code>snap</code> command? <a href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get set up for snaps.</a></p>
             </li>
-          
+
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Turn on standard services</h3>
-              
+
               <div class="p-code-copyable u-stepped-list-margin">
                 <input class="p-code-copyable__input" aria-label="microk8s.enable dashboard registry istio [...]" value="microk8s.enable dashboard registry istio [...]" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
-              
+
               <p class="p-stepped-list__content u-stepped-list-margin">
                 Similarly, <code>microk8s.disable</code> turns off a service. Try <code>microk8s.enable --help</code> for a list of available services built in.
               </p>
             </li>
-          
+
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Start Kubernetes</h3>
-              
+
               <div class="p-code-copyable u-stepped-list-margin">
                 <input class="p-code-copyable__input" aria-label="sudo microk8s.start" value="sudo microk8s.start" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
@@ -302,7 +317,7 @@ layout: base
           <ol class="p-stepped-list u-no-margin--left">
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Install Multipass for macOS</h3>
-              
+
               <p class="p-stepped-list__content u-stepped-list-margin">
                 <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--positive js-download" data-os="mac">
                   <span class="p-link--external">Download Multipass for macOS</span>
@@ -312,7 +327,7 @@ layout: base
 
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Launch a Multipass instance</h3>
-              
+
               <div class="p-code-copyable u-stepped-list-margin">
                 <input class="p-code-copyable__input" value="multipass launch --name foo" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
@@ -321,31 +336,31 @@ layout: base
 
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Install the microk8s snap</h3>
-              
+
               <div class="p-code-copyable u-stepped-list-margin">
                 <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic" value="sudo snap install microk8s --classic" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
-              
+
               <p class="p-stepped-list__content u-stepped-list-margin">Don’t have the <code>snap</code> command? <a href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get set up for snaps.</a></p>
             </li>
-          
+
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Turn on standard services</h3>
-              
+
               <div class="p-code-copyable u-stepped-list-margin">
                 <input class="p-code-copyable__input" aria-label="microk8s.enable dashboard registry istio [...]" value="microk8s.enable dashboard registry istio [...]" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
-              
+
               <p class="p-stepped-list__content u-stepped-list-margin">
                 Similarly, <code>microk8s.disable</code> turns off a service. Try <code>microk8s.enable --help</code> for a list of available services built in.
               </p>
             </li>
-          
+
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Start Kubernetes</h3>
-              
+
               <div class="p-code-copyable u-stepped-list-margin">
                 <input class="p-code-copyable__input" aria-label="sudo microk8s.start" value="sudo microk8s.start" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
@@ -398,19 +413,19 @@ layout: base
     var asciinemaContainer = document.querySelector('.asciinema-container');
     var clientWidth = document.documentElement.clientWidth;
     var asciinemaContent = '<script src="https://asciinema.org/a/jUPw2icctB5sSv2JW904qWSej.js" id="asciicast-jUPw2icctB5sSv2JW904qWSej"'+
-        'async="" data-player="[object HTMLDivElement]"><\/script>'+
-      '<div id="asciicast-container-jUPw2icctB5sSv2JW904qWSej" class="asciicast" style="display: block; float: none; overflow: hidden; padding: 0px; margin: 20px 0px;">'+
-        '<iframe class="lazyload" data-src="https://asciinema.org/a/jUPw2icctB5sSv2JW904qWSej/embed?" id="asciicast-iframe-jUPw2icctB5sSv2JW904qWSej"'+
-          'name="asciicast-iframe-jUPw2icctB5sSv2JW904qWSej" allow="fullscreen" style="overflow: hidden; margin: 0px; border: 0px; display: inline-block; width: 1140px; float: none; visibility: visible; height: 931px;"'+
-          'title="A number to steps to get started with MicroK8s">'+
-        '</iframe>'+
+    'async="" data-player="[object HTMLDivElement]"><\/script>'+
+    '<div id="asciicast-container-jUPw2icctB5sSv2JW904qWSej" class="asciicast" style="display: block; float: none; overflow: hidden; padding: 0px; margin: 20px 0px;">'+
+      '<iframe class="lazyload" data-src="https://asciinema.org/a/jUPw2icctB5sSv2JW904qWSej/embed?" id="asciicast-iframe-jUPw2icctB5sSv2JW904qWSej"'+
+      'name="asciicast-iframe-jUPw2icctB5sSv2JW904qWSej" allow="fullscreen" style="overflow: hidden; margin: 0px; border: 0px; display: inline-block; width: 1140px; float: none; visibility: visible; height: 931px;"'+
+      'title="A number to steps to get started with MicroK8s">'+
+      '</iframe>'+
       '</div>';
 
-    if (clientWidth >= 620 && asciinemaContainer) {
-      asciinemaContainer.innerHTML = asciinemaContent;
-    }
-  </script>
+      if (clientWidth >= 620 && asciinemaContainer) {
+        asciinemaContainer.innerHTML = asciinemaContent;
+      }
+    </script>
 
-  <script defer src="/js/copytoclipboard.js"></script>
-  <script defer src="/js/installversion.js"></script>
-  <script defer src="/js/tabs.js"></script>
+    <script defer src="/js/copytoclipboard.js"></script>
+    <script defer src="/js/installversion.js"></script>
+    <script defer src="/js/tabs.js"></script>


### PR DESCRIPTION
## Done

- Added KubeCon'19 banner to homepage

## QA

- Download this branch
- Run the site
- See that there is a banner per the [brief](https://docs.google.com/document/d/163wevrv2xmezH8PEmbRZRVhER1NOo64jFQesXkiNXW8/edit?ts=5dd2108c#)
- Fixes #166 

## Screenshot

![image](https://user-images.githubusercontent.com/441217/69044760-67b47400-09ed-11ea-9a2c-b72c7e70d004.png)
