### PR TITLE
Multipass exec mk8s

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,8 +358,6 @@ layout: base
                 <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic" value="sudo snap install microk8s --classic" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
-
-              <p class="p-stepped-list__content u-stepped-list-margin">Don’t have the <code>snap</code> command? <a href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get set up for snaps.</a></p>
             </li>
 
             <li class="p-stepped-list__item">

--- a/index.html
+++ b/index.html
@@ -273,7 +273,7 @@ layout: base
               <h3 class="p-stepped-list__title">Launch a Multipass instance</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" value="multipass launch --name foo" readonly="readonly">
+                <input class="p-code-copyable__input" value="multipass launch --name microk8s-vm --mem 4G --disk 40G" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
             </li>
@@ -282,7 +282,7 @@ layout: base
               <h3 class="p-stepped-list__title">Install the microk8s snap</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic" value="sudo snap install microk8s --classic" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo snap install microk8s --classic" value="multipass exec microk8s-vm -- sudo snap install microk8s --classic" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
 
@@ -293,7 +293,7 @@ layout: base
               <h3 class="p-stepped-list__title">Turn on standard services</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="microk8s.enable dashboard registry istio [...]" value="microk8s.enable dashboard registry istio [...]" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.enable dashboard registry istio [...]" value="multipass exec microk8s-vm -- sudo microk8s.enable dashboard registry istio [...]" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
 
@@ -306,7 +306,7 @@ layout: base
               <h3 class="p-stepped-list__title">Start Kubernetes</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="sudo microk8s.start" value="sudo microk8s.start" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.start" value="multipass exec microk8s-vm -- sudo microk8s.start" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
             </li>
@@ -329,7 +329,7 @@ layout: base
               <h3 class="p-stepped-list__title">Launch a Multipass instance</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" value="multipass launch --name foo" readonly="readonly">
+                <input class="p-code-copyable__input" value="multipass launch --name microk8s-vm --mem 4G --disk 40G" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
             </li>
@@ -338,7 +338,7 @@ layout: base
               <h3 class="p-stepped-list__title">Install the microk8s snap</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic" value="sudo snap install microk8s --classic" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo snap install microk8s --classic" value="multipass exec microk8s-vm -- sudo snap install microk8s --classic" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
 
@@ -349,7 +349,7 @@ layout: base
               <h3 class="p-stepped-list__title">Turn on standard services</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="microk8s.enable dashboard registry istio [...]" value="microk8s.enable dashboard registry istio [...]" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.enable dashboard registry istio [...]" value="multipass exec microk8s-vm -- sudo microk8s.enable dashboard registry istio [...]" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
 
@@ -362,7 +362,7 @@ layout: base
               <h3 class="p-stepped-list__title">Start Kubernetes</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="sudo microk8s.start" value="sudo microk8s.start" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.start" value="multipass exec microk8s-vm -- sudo microk8s.start" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
             </li>

--- a/index.html
+++ b/index.html
@@ -234,10 +234,19 @@ layout: base
             </li>
 
             <li class="p-stepped-list__item">
+              <h3 class="p-stepped-list__title">Check the status</h3>
+
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" aria-label="sudo microk8s.status --wait-ready" value="sudo microk8s.status --wait-ready" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
+            </li>
+
+            <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Turn on standard services</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="microk8s.enable dashboard registry istio [...]" value="microk8s.enable dashboard registry istio [...]" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="sudo microk8s.enable dns dashboard registry" value="sudo microk8s.enable dns dashboard registry" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
 
@@ -246,14 +255,6 @@ layout: base
               </p>
             </li>
 
-            <li class="p-stepped-list__item">
-              <h3 class="p-stepped-list__title">Start Kubernetes</h3>
-
-              <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="sudo microk8s.start" value="sudo microk8s.start" readonly="readonly">
-                <button class="p-code-copyable__action">Copy to clipboard</button>
-              </div>
-            </li>
           </ol>
         </div>
 
@@ -290,25 +291,25 @@ layout: base
             </li>
 
             <li class="p-stepped-list__item">
+              <h3 class="p-stepped-list__title">Check the status</h3>
+
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.status --wait-ready" value="multipass exec microk8s-vm -- sudo microk8s.status --wait-ready" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
+            </li>
+
+            <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Turn on standard services</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.enable dashboard registry istio [...]" value="multipass exec microk8s-vm -- sudo microk8s.enable dashboard registry istio [...]" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.enable dns dashboard registry istio" value="multipass exec microk8s-vm -- sudo microk8s.enable dns dashboard registry" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
 
               <p class="p-stepped-list__content u-stepped-list-margin">
                 Similarly, <code>microk8s.disable</code> turns off a service. Try <code>microk8s.enable --help</code> for a list of available services built in.
               </p>
-            </li>
-
-            <li class="p-stepped-list__item">
-              <h3 class="p-stepped-list__title">Start Kubernetes</h3>
-
-              <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.start" value="multipass exec microk8s-vm -- sudo microk8s.start" readonly="readonly">
-                <button class="p-code-copyable__action">Copy to clipboard</button>
-              </div>
             </li>
           </ol>
         </div>
@@ -346,10 +347,19 @@ layout: base
             </li>
 
             <li class="p-stepped-list__item">
+              <h3 class="p-stepped-list__title">Check the status</h3>
+
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.status --wait-ready" value="multipass exec microk8s-vm -- sudo microk8s.status --wait-ready" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
+            </li>
+
+            <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Turn on standard services</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.enable dashboard registry istio [...]" value="multipass exec microk8s-vm -- sudo microk8s.enable dashboard registry istio [...]" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.enable dns dashboard registry" value="multipass exec microk8s-vm -- sudo microk8s.enable dns dashboard registry istio" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
 
@@ -358,14 +368,6 @@ layout: base
               </p>
             </li>
 
-            <li class="p-stepped-list__item">
-              <h3 class="p-stepped-list__title">Start Kubernetes</h3>
-
-              <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.start" value="multipass exec microk8s-vm -- sudo microk8s.start" readonly="readonly">
-                <button class="p-code-copyable__action">Copy to clipboard</button>
-              </div>
-            </li>
           </ol>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -280,21 +280,28 @@ layout: base
             </li>
 
             <li class="p-stepped-list__item">
+              <h3 class="p-stepped-list__title">Enter the VM instance</h3>
+
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" aria-label="multipass shell microk8s-vm" value="multipass shell microk8s-vm" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
+            </li>
+
+            <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Install the microk8s snap</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo snap install microk8s --classic" value="multipass exec microk8s-vm -- sudo snap install microk8s --classic" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic" value="sudo snap install microk8s --classic" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
-
-              <p class="p-stepped-list__content u-stepped-list-margin">Don’t have the <code>snap</code> command? <a href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get set up for snaps.</a></p>
             </li>
 
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Check the status</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.status --wait-ready" value="multipass exec microk8s-vm -- sudo microk8s.status --wait-ready" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="sudo microk8s.status --wait-ready" value="sudo microk8s.status --wait-ready" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
             </li>
@@ -303,7 +310,7 @@ layout: base
               <h3 class="p-stepped-list__title">Turn on standard services</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.enable dns dashboard registry istio" value="multipass exec microk8s-vm -- sudo microk8s.enable dns dashboard registry" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="sudo microk8s.enable dns dashboard registry istio" value="sudo microk8s.enable dns dashboard registry" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
 
@@ -336,10 +343,19 @@ layout: base
             </li>
 
             <li class="p-stepped-list__item">
+              <h3 class="p-stepped-list__title">Enter the VM instance</h3>
+
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" aria-label="multipass shell microk8s-vm" value="multipass shell microk8s-vm" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
+            </li>
+
+            <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Install the microk8s snap</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo snap install microk8s --classic" value="multipass exec microk8s-vm -- sudo snap install microk8s --classic" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic" value="sudo snap install microk8s --classic" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
 
@@ -350,7 +366,7 @@ layout: base
               <h3 class="p-stepped-list__title">Check the status</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.status --wait-ready" value="multipass exec microk8s-vm -- sudo microk8s.status --wait-ready" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="sudo microk8s.status --wait-ready" value="sudo microk8s.status --wait-ready" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
             </li>
@@ -359,7 +375,7 @@ layout: base
               <h3 class="p-stepped-list__title">Turn on standard services</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="multipass exec microk8s-vm -- sudo microk8s.enable dns dashboard registry" value="multipass exec microk8s-vm -- sudo microk8s.enable dns dashboard registry istio" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="sudo microk8s.enable dns dashboard registry" value="sudo microk8s.enable dns dashboard registry" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
 


### PR DESCRIPTION
@evilnick, all, please review, merge this PR and update the site before the US wakes up. We have people at KubeCon trying these instructions and fail. 

Changes on this PR:
- multipass creates VM with enough RAM and disk (thanks @kwmonroe)
- we use `multipass shell` to enter the VM. This shows better than the `multipass exec` 
- we do a `microk8s.status --wait-ready` to wait for MicroK8s to start
- do not suggest installing snapd in VMs, it is already there
- do not do `microk8s.start` since it has already started
- remove the `[...]` from the list of addons
- `microk8s.enable dns` and not istio. istio is not a standard service and it also takes along time to setup so it is not a good example for a quick start.