### PR TITLE
Remove kubecon notice

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,21 +24,6 @@ layout: base
     </div>
   </section>
 
-  <section class="p-strip--light is-shallow">
-    <div class="row u-equal-height">
-      <div class="col-2 u-vertically-center">
-        <img class="u-hide--small u-no-margin--bottom" style="height: 50px; margin-bottom: .95rem;" src="https://portworx.com/wp-content/uploads/2017/02/kubecon-logo.png" height="50" alt="">
-      </div>
-      <div class="col-10 u-vertically-center">
-        <h4 class="u-no-max-width u-no-margin--bottom">
-          <a class="p-link--external" href="https://ubuntu.com/blog/ubuntu-kubecon-americas-2019">
-            Visit the Ubuntu booth (P36) at Kubecon’19 to win a MicroK8s t-shirt
-          </a>
-        </h4>
-      </div>
-    </div>
-  </section>
-
   <section class="p-strip">
     <div class="row">
       <div class="col-6">


### PR DESCRIPTION
## Done

Removed the kubcon19 notice from the homepage

## QA

- Download this branch
- Look at http://0.0.0.0:8027/
- See that the notice has been removed
