### PR TITLE
Downloads are not external links

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@ layout: base
 
               <p class="p-stepped-list__content u-stepped-list-margin">
                 <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--positive js-download" data-os="win-win">
-                  <span class="p-link--external">Download Multipass for Windows</span>
+                  Download Multipass for Windows
                 </a>
               </p>
             </li>
@@ -313,7 +313,7 @@ layout: base
 
               <p class="p-stepped-list__content u-stepped-list-margin">
                 <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--positive js-download" data-os="mac">
-                  <span class="p-link--external">Download Multipass for macOS</span>
+                  Download Multipass for macOS
                 </a>
               </p>
             </li>


### PR DESCRIPTION
Removes external-link icons from “Download Multipass” buttons.

A download does not take you to a new page, so it isn’t an external link as people typically understand them.

I requested these icons be dropped when I reviewed microstack.run, but I missed them on microk8s.io.