### PR TITLE
Update registry-images.md

### DIFF
--- a/docs/registry-images.md
+++ b/docs/registry-images.md
@@ -72,16 +72,16 @@ Docker daemon and "inject" it into the  MicroK8s image cache like this:
 
 ```bash
 docker save mynginx > myimage.tar
-microk8s.ctr -n k8s.io image import myimage.tar
+microk8s.ctr --namespace k8s.io image import myimage.tar
 ```
 
 Note that when we import the image to MicroK8s we do so under the `k8s.io`
-namespace (the `-n k8s.io` argument).
+namespace (the `--namespace k8s.io` argument).
 
 Now we can list the images present in MicroK8s:
 
 ```bash
-microk8s.ctr -n k8s.io images ls
+microk8s.ctr --namespace k8s.io images ls
 ```
 
 At this point we are ready to `microk8s.kubectl apply -f` a deployment with


### PR DESCRIPTION
$ microk8s.ctr -n k8s.io images ls
Cannot use two forms of the same flag: n namespace
<<snip>>
$ microk8s.ctr --namespace k8s.io images ls
<<snip>>
Using --namespace instead of -n showed the correct output.
$ microk8s.ctr version
Client:
  Version:  v1.2.5
  Revision: bb71b10fd8f58240ca47fbb579b9d1028eea7c84

Server:
  Version:  v1.2.5
  Revision: bb71b10fd8f58240ca47fbb579b9d1028eea7c84