### PR TITLE
Fix the copy functionality in the docs

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -113,3 +113,5 @@ layout: base
     </footer>
   </main>
 </div>
+
+<script src="/js/copytoclipboard.js" defer></script>


### PR DESCRIPTION
## Done
Fix the copy functionality in the docs

## QA
- Go to /docs
- Click one of the copy to clipboard buttons
- Check it works

Fixes https://github.com/canonical-web-and-design/microk8s.io/issues/197