### PR TITLE
Adding a proxy installation/configuration page

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -24,6 +24,7 @@ layout: base
               <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/docs/install-alternatives#windows">&nbsp;&nbsp;&nbsp;&nbsp;- Windows10</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/docs/install-alternatives#macos">&nbsp;&nbsp;&nbsp;&nbsp;- macOS</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/docs/install-alternatives#arm">&nbsp;&nbsp;&nbsp;&nbsp;- Raspberry PI/ARM</a></li>
+              <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/docs/install-proxy">&nbsp;&nbsp;&nbsp;&nbsp;- Behind a proxy</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/docs/setting-snap-channel">Channels, releases and upgrades</a></li>
             </ul>
             <strong>Add-ons</strong>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -24,7 +24,7 @@ layout: base
               <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/docs/install-alternatives#windows">&nbsp;&nbsp;&nbsp;&nbsp;- Windows10</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/docs/install-alternatives#macos">&nbsp;&nbsp;&nbsp;&nbsp;- macOS</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/docs/install-alternatives#arm">&nbsp;&nbsp;&nbsp;&nbsp;- Raspberry PI/ARM</a></li>
-              <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/docs/install-proxy">&nbsp;&nbsp;&nbsp;&nbsp;- Behind a proxy</a></li>
+              <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/docs/install-proxy">Behind a proxy</a></li>
               <li class="p-sidebar-nav__item"><a class="p-link--soft" href="/docs/setting-snap-channel">Channels, releases and upgrades</a></li>
             </ul>
             <strong>Add-ons</strong>

--- a/docs/install-proxy.md
+++ b/docs/install-proxy.md
@@ -1,0 +1,25 @@
+---
+layout: docs
+title: "Install behind a proxy"
+permalink: /docs/install-proxy
+---
+
+# Install behind a proxy
+
+To let MicroK8s use a proxy enter the proxy details in 
+`${SNAP_DATA}/args/containerd-env` (normally `/var/snap/microk8s/current/args/containerd-env`) and restart with:
+
+```bash
+microk8s.stop
+microk8s.start
+```
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the docs. You can 
+    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/install-proxy.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/docs/install-proxy.md
+++ b/docs/install-proxy.md
@@ -6,8 +6,19 @@ permalink: /docs/install-proxy
 
 # Install behind a proxy
 
-To let MicroK8s use a proxy enter the proxy details in 
-`${SNAP_DATA}/args/containerd-env` (normally `/var/snap/microk8s/current/args/containerd-env`) and restart with:
+To let MicroK8s use a proxy we need to enter the proxy details in 
+`${SNAP_DATA}/args/containerd-env` (normally `/var/snap/microk8s/current/args/containerd-env`). The `containerd-env` file holds the environment variables containerd runs with. Setting the `HTTPS_PROXY` to your proxy endpoint enables containerd to fetch conatiner images from the web. Here is an example where `HTTPS_PROXY` is set to `https://squid.internal:3128`:
+
+```
+HTTPS_PROXY=https://squid.internal:3128
+#
+# Some additional environment variables
+#
+ulimit -n 65536 || true
+ulimit -l 16384 || true
+```
+
+For the changes to take effect we need to restart MicroK8s:
 
 ```bash
 microk8s.stop


### PR DESCRIPTION
This has come up a lot of times in the issues (most recently in https://github.com/ubuntu/microk8s/issues/917).

I added the proxy setup as part of the installation process instead of the configuration because if the proxy is not set you see immediately the system is not running correctly. Your thoughts on that @evilnick?
