### PR TITLE
Add a variable for the date in the footer's copyright

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -94,7 +94,7 @@ layout: base
     <footer class="p-footer" role="contentinfo">
       <div class="l-docs-row u-no-margin--left">
         <div class="col-12">
-          <p>&copy; 2019 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+          <p>&copy; {{ 'now' | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
           <nav>
             <ul class="p-inline-list--middot">
               <li class="p-inline-list__item">

--- a/index.html
+++ b/index.html
@@ -404,7 +404,7 @@ layout: base
             MicroK8s was built by the dedicated <a href="https://www.ubuntu.com/kubernetes">Kubernetes team at Canonical</a> for the developer community. We also make <a href="https://ubuntu.com/kubernetes/install#cluster">the Charmed Distribution of Kubernetes</a> for multi-cloud scalable clusters.
           </p>
           <p class="u-no-max-width">
-            © 2019 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.
+            © {{ 'now' | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.
           </p>
           <nav>
             <ul class="p-inline-list--middot">


### PR DESCRIPTION
## Done

- Added a jekyll variable for the year in the footer's copyright

## QA

- Download this branch
- ./run the site
- See the footer says 2020

Fixes #212 