### PR TITLE
Copy change on microk8s.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@ layout: base
       <div class="row">
         <div>
           <p>
-            MicroK8s was built by the dedicated <a href="https://www.ubuntu.com/kubernetes">Kubernetes team at Canonical</a> for the developer community. We also make <a href="https://ubuntu.com/kubernetes/install#cluster">the Charmed Distribution of Kubernetes</a> for multi-cloud scalable clusters.
+            MicroK8s was built by the dedicated <a href="https://www.ubuntu.com/kubernetes">Kubernetes team at Canonical</a> for the developer community. We also make <a href="https://ubuntu.com/kubernetes/install#cluster">the Charmed Kubernetes</a> for multi-cloud scalable clusters.
           </p>
           <p class="u-no-max-width">
             © {{ 'now' | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.

--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@ layout: base
       <div class="row">
         <div>
           <p>
-            MicroK8s was built by the dedicated <a href="https://www.ubuntu.com/kubernetes">Kubernetes team at Canonical</a> for the developer community. We also make <a href="https://ubuntu.com/kubernetes/install#cluster">the Charmed Kubernetes</a> for multi-cloud scalable clusters.
+            MicroK8s was built by the dedicated <a href="https://www.ubuntu.com/kubernetes">Kubernetes team at Canonical</a> for the developer community. We also make <a href="https://ubuntu.com/kubernetes/install#cluster">Charmed Kubernetes</a> for multi-cloud scalable clusters.
           </p>
           <p class="u-no-max-width">
             © {{ 'now' | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.


### PR DESCRIPTION
## Done
Removing " Distribution of" from "Charmed Distribution of Kubernetes"

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare it against the [copy doc](https://docs.google.com/document/d/1ObWmhRc4GCIhrBi8gT7yIIs0J_dn_8ravfLtcwhr3uQ/edit?ts=5e32f329) and accepts correct changes.

