### PR TITLE
Ask users to gain access to ~/.kube dir

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,9 +48,13 @@ MicroK8s will install a minimal, lightweight Kubernetes you can run and use on p
         <div class="p-stepped-list__content">
 
 MicroK8s creates a group to enable seamless usage of commands which require admin privilege. To add your current user
-to the group, run the following:
+to the group and gain access to the <code>.kube</code> caching directory, run the following two commands:
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="sudo usermod -a -G microk8s $USER" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
+          </div>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="sudo chown -f -R $USER ~/.kube" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           You will also need to re-enter the session for the group update to take place:


### PR DESCRIPTION
## Done

This PR adds an additional command in the "Quick Start" guide: `sudo chown -f -R $USER ~/.kube`. This command is needed because if the user had ever run a `microk8s.kubectl` command with `sudo` the `~/.kube` directory would have been created with `root:root` permissions. As soon as the user enters the `microk8s` group she would be able to run the `microk8s.*` commands but the commands would be blocked from accessing `~/.kube` directory. The effect of this block is `microk8s.kubectl` taking minutes to complete. See for example the issue [0]. 

Note, with PR [1] we also prompt the user to gain access to the `~/.kube` directory in addition to adding himself to the microk8s group.

[0] https://github.com/ubuntu/microk8s/issues/1023
[1] https://github.com/ubuntu/microk8s/pull/1027

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes https://github.com/ubuntu/microk8s/issues/1023

## Screenshots

[if relevant, include a screenshot]
