### PR TITLE
Remove beta label from Clustering

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ layout: base
           <li class="p-list__item is-ticked">Conformant</li>
           <li class="p-list__item is-ticked">Istio</li>
           <li class="p-list__item is-ticked">Storage</li>
-          <li class="p-list__item is-ticked">Clustering <small class="p-label--in-progress">BETA</small></li>
+          <li class="p-list__item is-ticked">Clustering</li>
         </ul>
       </div>
 


### PR DESCRIPTION
## Done

- Removed the 'BETA' label on the Clustering feature

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and update the [copy doc](https://docs.google.com/document/d/1ObWmhRc4GCIhrBi8gT7yIIs0J_dn_8ravfLtcwhr3uQ/edit)

## Issue / Card

Fixes #231

