### PR TITLE
remove js class rewriting download link

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,7 +258,7 @@ layout: base
               <h3 class="p-stepped-list__title">Download the installer for Windows</h3>
 
               <p class="p-stepped-list__content u-stepped-list-margin">
-                <a href="https://github.com/ubuntu/microk8s/releases/download/installer-v1.0.0/microk8s-installer.exe" class="p-button--positive js-download" data-os="win-win">
+                <a href="https://github.com/ubuntu/microk8s/releases/download/installer-v1.0.0/microk8s-installer.exe" class="p-button--positive">
                   <span class="p-link--external">Download MicroK8s for Windows</span>
                 </a>
               </p>


### PR DESCRIPTION
## Done

removed class causing download to get rewritten. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- check link works


## Issue / Card

Fixes #241