### PR TITLE
revert docs to old commands/no-installer

### DIFF
--- a/docs/addon-dashboard.md
+++ b/docs/addon-dashboard.md
@@ -10,7 +10,7 @@ The standard Kubernetes Dashboard is a convenient way to keep track of the
 activity and resource use of MicroK8s
 
 ```bash
-microk8s enable dashboard
+microk8s.enable dashboard
 ```
 
 To log in to the Dashboard, you will need the access token (unless RBAC has
@@ -18,10 +18,10 @@ also been enabled). This is generated randomly on deployment, so a few commands
 are needed to retrieve it:
 
 ```bash
-token=$(microk8s kubectl -n kube-system get secret | grep default-token | cut -d " " -f1)
-microk8s kubectl -n kube-system describe secret $token
+token=$(microk8s.kubectl -n kube-system get secret | grep default-token | cut -d " " -f1)
+microk8s.kubectl -n kube-system describe secret $token
 ```
-In an RBAC enabled setup (`microk8s enable rbac`) you need to create a user with
+In an RBAC enabled setup (`microk8s.enable rbac`) you need to create a user with
 restricted permissions as detailed in the
 [upstream Dashboard access control documentation ][upstream-dashboard]
 
@@ -30,17 +30,17 @@ have an IP address on your local network (the Cluster IP of the kubernetes-dashb
 you can also reach the dashboard by forwarding its port to a free one on your host with:
 
 ```bash
-microk8s kubectl port-forward -n kube-system service/kubernetes-dashboard 10443:443
+microk8s.kubectl port-forward -n kube-system service/kubernetes-dashboard 10443:443
 ```
 
 You can then access the Dashboard at [https://127.0.0.1:10443](https://127.0.0.1:10443)
 
 If you are running MicroK8s in a VM and you need to expose the Dashboard to other hosts, you
 should also use the `--address [IP_address_that_your_browser's_host_has]` option. Set this option
-to `--address 0.0.0.0` to make the Dashboard public. For example:
+to `--address 0.0.0.0` to make the Dashboard public. For example: 
 
 ```bash
-microk8s kubectl port-forward -n kube-system service/kubernetes-dashboard 10443:443 --address 0.0.0.0
+microk8s.kubectl port-forward -n kube-system service/kubernetes-dashboard 10443:443 --address 0.0.0.0
 ```
 
 Visit the [upstream dashboard documentation][upstream-access-dashboard] to find out other ways to reach the Dashboard.
@@ -55,9 +55,9 @@ Visit the [upstream dashboard documentation][upstream-access-dashboard] to find 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
+    We appreciate your feedback on the docs. You can 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/addon-dashboard.md" class="p-notification__action">edit this page</a>
-    or
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/docs/addon-dns.md
+++ b/docs/addon-dns.md
@@ -14,14 +14,14 @@ This service is commonly required by other addons, so it is
 recommended that you enable it.
 
 ```bash
-microk8s enable dns
+microk8s.enable dns
 ```
 
 By default it points to Google's `8.8.8.8` and `8.8.4.4` servers for resolving
 addresses. This can be changed by running the command:
 
 ```bash
-microk8s kubectl -n kube-system edit configmap/coredns
+microk8s.kubectl -n kube-system edit configmap/coredns
 ```
 
 This will invoke the `vim` editor so that you can alter the configuration.
@@ -29,7 +29,7 @@ This will invoke the `vim` editor so that you can alter the configuration.
 The addon can be disabled at any time:
 
 ```bash
-microk8s disable dns
+microk8s.disable dns
 ```
 
 ...but bear in mind this could have implications for services and pods which
@@ -37,10 +37,9 @@ may be relying on it.
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
-    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/addon-dns.md" class="p-notification__action">edit this page</a>
-    or
+    We appreciate your feedback on the docs. You can 
+    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/addon-dns.md" class="p-notification__action">edit this page</a> 
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>
-microk8s

--- a/docs/addon-fluentd.md
+++ b/docs/addon-fluentd.md
@@ -12,13 +12,13 @@ to MicroK8s. The components will be installed and connected together.
 To enable the addon:
 
 ```bash
-microk8s enable fluentd
+microk8s.enable fluentd
 ```
 
 To access the Kibana dashboard, you should first start the kube proxy service:
 
 ```bash
-microk8s kubectl proxy
+microk8s.kubectl proxy
 ```
 
 You will now find the dashboard available at:
@@ -31,7 +31,7 @@ and the [official Kibana documentation][kibana-docs].
 The addon can be disabled at any time with the command:
 
 ```bash
-microk8s disable fluentd
+microk8s.disable fluentd
 ```
 
 
@@ -41,9 +41,9 @@ microk8s disable fluentd
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
-    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/addon-fluentd.md" class="p-notification__action">edit this page</a>
-    or
+    We appreciate your feedback on the docs. You can 
+    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/addon-fluentd.md" class="p-notification__action">edit this page</a> 
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/docs/addon-gpu.md
+++ b/docs/addon-gpu.md
@@ -9,7 +9,7 @@ permalink: /docs/addon-gpu
 This addon enables NVIDIA GPU support for MicroK8s.
 
 ```bash
-microk8s enable gpu
+microk8s.enable gpu
 ```
 
 Note that this is obviously dependent on the host system having suitable
@@ -35,9 +35,9 @@ spec:
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
-    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/addon-gpu.md" class="p-notification__action">edit this page</a>
-    or
+    We appreciate your feedback on the docs. You can 
+    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/addon-gpu.md" class="p-notification__action">edit this page</a> 
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/docs/addon-linkerd.md
+++ b/docs/addon-linkerd.md
@@ -10,7 +10,7 @@ Enabling this addon will deploy the necessary services and proxies for the
 linkerd service mesh.
 
 ```bash
-microk8s enable linkerd
+microk8s.enable linkerd
 ```
 
 Linkerd includes a command line utility. For convenience, MicroK8s ships
@@ -18,7 +18,7 @@ with this utility. You can verify that the utility and linkerd are
 configured and working by running:
 
 ```bash
-microk8s linkerd check
+microk8s.linkerd check
 ```
 
 For more on linkerd, see the

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -26,20 +26,20 @@ any further set up.
 For example, to enable the CoreDNS addon:
 
 ```bash
-microk8s enable dns
+microk8s.enable dns
 ```
 
 These add-ons can be disabled at anytime using the `disable` command:
 
 ```bash
-microk8s disable dns
+microk8s.disable dns
 ```
 
 ... and you can check the list of available and installed addons at any time
 by running:
 
 ```bash
-microk8s status
+microk8s.status
 ```
 
 <a id="list"> </a>
@@ -58,7 +58,7 @@ monitoring solution.
 
 [**gpu**](addon-gpu):  Enable support for GPU accelerated workloads using the NVIDIA runtime.
 
-**helm**: Installs the [Helm 2][] package manager for Kubernetes.
+**helm**: Installs the [Helm 2][] package manager for Kubernetes. 
 
 **ingress**: A simple ingress controller for external access.
 
@@ -115,9 +115,9 @@ work under multipass on macOS, due to filtering that macOS applies to network tr
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
-    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/addons.md" class="p-notification__action">edit this page</a>
-    or
+    We appreciate your feedback on the docs. You can 
+    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/addons.md" class="p-notification__action">edit this page</a> 
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -8,35 +8,35 @@ permalink: /docs/clustering
 ## Adding a node
 
 To create a cluster out of two or more already-running MicroK8s instances,
-use the `microk8s add-node` command. The MicroK8s instance on which this
+use the `microk8s.add-node` command. The MicroK8s instance on which this
 command is
 run will be the master of the cluster and will host the Kubernetes
 control plane:
 
 ```bash
-microk8s add-node
-Join node with: microk8s join ip-172-31-20-243:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
+microk8s.add-node
+Join node with: microk8s.join ip-172-31-20-243:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
 
 If the node you are adding is not reachable through the default
 interface you can use one of the following:
 
- microk8s join 10.1.84.0:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
- microk8s join 10.22.254.77:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
+ microk8s.join 10.1.84.0:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
+ microk8s.join 10.22.254.77:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
 ```
 
-The `add-node` command prints a `microk8s join` command which should
+The `add-node` command prints a `microk8s.join` command which should
 be executed on the MicroK8s instance that you wish to join to the
 cluster:
 
 ```bash
-microk8s join ip-172-31-20-243:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
+microk8s.join ip-172-31-20-243:25000/DDOkUupkmaBezNnMheTBqFYHLWINGDbf
 ```
 
 Joining a node to the cluster should only take a few seconds. Afterwards
 you should be able to see the node has joined:
 
 ```bash
-microk8s kubectl get no
+microk8s.kubectl get no
 ```
 ```no-highlight
 NAME               STATUS   ROLES    AGE   VERSION
@@ -46,17 +46,17 @@ ip-172-31-20-243   Ready    <none>   53s   v1.15.3
 
 ## Removing a node
 
-To remove a node from the cluster, use `microk8s remove-node`:
+To remove a node from the cluster, use `microk8s.remove-node`:
 
 ```bash
-microk8s remove-node 10.22.254.79
+microk8s.remove-node 10.22.254.79
 ```
 
-Finally, on the removed node, run `microk8s leave`. MicroK8s will restart
+Finally, on the removed node, run `microk8s.leave`. MicroK8s will restart
 its own control plane and resume operations as a full single node cluster:
 
 ```bash
-microk8s leave
+microk8s.leave
 ```
 
 <!-- FEEDBACK -->

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,74 +6,75 @@ permalink: /docs/commands
 
 # Command Reference
 
-MicroK8s adds the 'microk8s' command with a number of commands:
+MicroK8s adds a number of commands, grouped together with a 'microk8s.' prefix
+for convenience.
 
--   [microk8s add-node](#microk8s-add-node)
--   [microk8s config](#microk8s-config)
--   [microk8s ctr](#microk8s-ctr)
--   [microk8s disable](#microk8s-disable)
--   [microk8s enable](#microk8s-enable)
--   [microk8s inspect](#microk8s-inspect)
--   [microk8s join](#microk8s-join)
--   [microk8s kubectl](#microk8s-kubectl)
--   [microk8s leave](#microk8s-leave)
--   [microk8s remove-node](#microk8s-remove-node)  
--   [microk8s reset](#microk8s-reset)
--   [microk8s start](#microk8s-start)
--   [microk8s status](#microk8s-status)
--   [microk8s stop](#microk8s-stop)
+-   [microk8s.add-node](#microk8s.add-node)
+-   [microk8s.config](#microk8s.config)
+-   [microk8s.ctr](#microk8s.ctr)
+-   [microk8s.disable](#microk8s.disable)
+-   [microk8s.enable](#microk8s.enable)
+-   [microk8s.inspect](#microk8s.inspect)
+-   [microk8s.join](#microk8s.join)
+-   [microk8s.kubectl](#microk8s.kubectl)
+-   [microk8s.leave](#microk8s.leave)
+-   [microk8s.remove-node](#microk8s.remove-node)  
+-   [microk8s.reset](#microk8s.reset)
+-   [microk8s.start](#microk8s.start)
+-   [microk8s.status](#microk8s.status)
+-   [microk8s.stop](#microk8s.stop)
 
 ## Addon helper commands
 
 Some commands are specific to particular addons (e.g.
-`microk8s cilium`) and may not do anything useful if the respective addon is
+`microk8s.cilium`) and may not do anything useful if the respective addon is
 not currently enabled. For more information on these commands, see the
 [Addon documentation](addons).
 
--   `microk8s cilium`
--   `microk8s helm`
--   `microk8s istioctl`
--   `microk8s linkerd`
+-   `microk8s.cilium`
+-   `microk8s.helm`
+-   `microk8s.istioctl`
+-   `microk8s.linkerd`
 
 ---
-<a id="microk8s-add-node"> </a>
-### microk8s add-node
+<a id="microk8s.add-node"> </a>
+### microk8s.add-node
 
-**Usage:** `microk8s add-node`
+**Usage:** `microk8s.add-node`
 
 **Options:**
 
 **Description:**
 Running this command will generate a connection string and output a list of
-suggested `microk8s join` commands to add an additional MicroK8s node to
+suggested `microk8s.join` commands to add an additional MicroK8s node to
 the current cluster.
 
 **Examples:**
 
-`microk8s add-node`
+`microk8s.add-node`
 
 ...will result in output similar to:
 
 ```no-highlight
-Join node with: microk8s join 192.168.0.2:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
+Join node with: microk8s.join 192.168.0.2:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
 
 If the node you are adding is not reachable through the default interface you can
 use one of the following:
- microk8s join 192.168.0.2:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
- microk8s join 192.168.250.1:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
- microk8s join 10.57.200.1:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
- microk8s join 10.128.63.1:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
- microk8s join 172.17.0.1:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
- microk8s join 10.1.37.68:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
- microk8s join 192.168.122.1:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
+ microk8s.join 192.168.0.2:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
+ microk8s.join 192.168.250.1:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
+ microk8s.join 10.57.200.1:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
+ microk8s.join 10.128.63.1:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
+ microk8s.join 172.17.0.1:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
+ microk8s.join 10.1.37.68:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
+ microk8s.join 192.168.122.1:25000/eLCTbltkDzxOnSKAkmVMbOPYgSrAieEl
 ```
 
 ---
 
-<a id="microk8s-config"> </a>
-### microk8s config
+<a id="microk8s.config"> </a>
+### microk8s.config
 
-**Usage:** `microk8s config [-l]`
+**Usage:** `microk8s.config [-l]`
 
 **Options:**
 
@@ -86,7 +87,7 @@ to that returned by `kubectl`).
 
 **Examples:**
 
-`microk8s config`
+`microk8s.config`
 
 ...will result in output similar to:
 
@@ -113,10 +114,10 @@ users:
 
 ```
 ---
-<a id="microk8s-ctr"> </a>
-### microk8s ctr
+<a id="microk8s.ctr"> </a>
+### microk8s.ctr
 
-**Usage:** `microk8s ctr [command]`
+**Usage:** `microk8s.ctr [command]`
 
 **Options:**
 
@@ -126,11 +127,11 @@ users:
 This command provides access to the containerd CLI command `ctr`. It is
 provided as a convenience, for more information on
 using `ctr`, please see the relevant manpage with `man ctr` or run the built-in
-help with `microk8s ctr`.
+help with `microk8s.ctr`.
 
 **Examples:**
 
-`microk8s ctr version`
+`microk8s.ctr version`
 
 ...will result in output similar to:
 
@@ -142,10 +143,10 @@ Client:
 
 ---
 
-<a id="microk8s-disable"> </a>
-### microk8s disable
+<a id="microk8s.disable"> </a>
+### microk8s.disable
 
-**Usage:** `microk8s disable addon [addon ...]`
+**Usage:** `microk8s.disable addon [addon ...]`
 
 **Options:**
 
@@ -159,7 +160,7 @@ continue to work properly if addons are removed.
 
 **Examples:**
 
-`microk8s disable dns`
+`microk8s.disable dns`
 
 ...will usually result in output detailing what has been done. In this case,
 the ouput will be similar to:
@@ -179,10 +180,10 @@ clusterrolebinding.rbac.authorization.k8s.io "coredns" deleted
 
 ---
 
-<a id="microk8s-enable"> </a>
-### microk8s enable
+<a id="microk8s.enable"> </a>
+### microk8s.enable
 
-**Usage:** `microk8s enable addon [addon ... ]`
+**Usage:** `microk8s.enable addon [addon ... ]`
 
 **Options:**
 
@@ -195,11 +196,11 @@ MicroK8s to enable it. For more details, see the documentation for the
 specific addon in question in the [addons documentation](addons).
 
 For a list of the current available addons, and whether or not they are
-enabled, run `microk8s status`.
+enabled, run `microk8s.status`.
 
 **Examples:**
 
-`microk8s enable storage`
+`microk8s.enable storage`
 
 ...will result in output similar to:
 
@@ -215,36 +216,36 @@ Storage will be available soon
 
 ---
 
-<a id="microk8s-inspect"> </a>
-### microk8s inspect
+<a id="microk8s.inspect"> </a>
+### microk8s.inspect
 
-**Usage:** `microk8s inspect`
+**Usage:** `microk8s.inspect`
 
 **Options:**
 
 
 **Description:**
 This command creates a detailed profile of the current state of the running
-MicroK8s.  This is primarily useful for troubleshooting and reporting bugs.
+MicroK8s. This is primarily useful for troubleshooting and reporting bugs.
 
 **Examples:**
 
-`microk8s inspect`
+`microk8s.inspect`
 
 ...will result in output similar to:
 
 ```no-highlight
 Inspecting services
-  Service snap.microk8s daemon-cluster-agent is running
-  Service snap.microk8s daemon-flanneld is running
-  Service snap.microk8s daemon-containerd is running
-  Service snap.microk8s daemon-apiserver is running
-  Service snap.microk8s daemon-apiserver-kicker is running
-  Service snap.microk8s daemon-proxy is running
-  Service snap.microk8s daemon-kubelet is running
-  Service snap.microk8s daemon-scheduler is running
-  Service snap.microk8s daemon-controller-manager is running
-  Service snap.microk8s daemon-etcd is running
+  Service snap.microk8s.daemon-cluster-agent is running
+  Service snap.microk8s.daemon-flanneld is running
+  Service snap.microk8s.daemon-containerd is running
+  Service snap.microk8s.daemon-apiserver is running
+  Service snap.microk8s.daemon-apiserver-kicker is running
+  Service snap.microk8s.daemon-proxy is running
+  Service snap.microk8s.daemon-kubelet is running
+  Service snap.microk8s.daemon-scheduler is running
+  Service snap.microk8s.daemon-controller-manager is running
+  Service snap.microk8s.daemon-etcd is running
   Copy service arguments to the final report tarball
 Inspecting AppArmor configuration
 Gathering system information
@@ -267,34 +268,34 @@ Building the report tarball
 
 ---
 
-<a id="microk8s-join"> </a>
-### microk8s join
+<a id="microk8s.join"> </a>
+### microk8s.join
 
-**Usage:** `microk8s join <master>:<port>/<token>`
+**Usage:** `microk8s.join <master>:<port>/<token>`
 
 **Options:**
 
 **Description:**
 Used to join the local MicroK8s node in to a remote cluster. An 'invitation' in
 the form of a token is required, which is issued by running the
-`microk8s add-node` command on the master MicroK8s node.
+`microk8s.add-node` command on the master MicroK8s node.
 
-Running `microk8s add-node` will output a number of different commands which can
+Running `microk8s.add-node` will output a number of different commands which can
 be used from the node wishing to join, taking into account different
-network addressing. The `microk8s join` command will need the address and port
+network addressing. The `microk8s.join` command will need the address and port
 number of the master node, as well as the token, in order for this command to
 be successful.
 
 **Examples:**
 
-`microk8s join 10.128.63.163:25000/JGoShFJfHtbieSOsMhmkgsOHrwtxDKRH`
+`microk8s.join 10.128.63.163:25000/JGoShFJfHtbieSOsMhmkgsOHrwtxDKRH`
 
 ---
 
-<a id="microk8s-kubectl"> </a>
-### microk8s kubectl
+<a id="microk8s.kubectl"> </a>
+### microk8s.kubectl
 
-**Usage:** `microk8s kubectl [command]`
+**Usage:** `microk8s.kubectl [command]`
 
 **Options:**
 
@@ -305,7 +306,7 @@ This command runs the standard Kubernetes `kubectl` which ships with MicroK8s.
 
 **Examples:**
 
-`microk8s kubectl get all`
+`microk8s.kubectl get all`
 
 ...will result in output similar to:
 
@@ -317,28 +318,28 @@ service/kubernetes   ClusterIP   10.152.183.1   <none>        443/TCP   108m
 
 ---
 
-<a id="microk8s-leave"> </a>
-### microk8s leave
+<a id="microk8s.leave"> </a>
+### microk8s.leave
 
-**Usage:** `microk8s leave`
+**Usage:** `microk8s.leave`
 
 **Options:**
 
 **Description:**
-When run on a node which has previously joined a cluster with `microk8s join`,
+When run on a node which has previously joined a cluster with `microk8s.join`,
 this command will remove the current node from the cluster and return it to
 single node operation.
 
 **Examples:**
 
-`microk8s leave`
+`microk8s.leave`
 
 ---
 
-<a id="microk8s-remove-node"> </a>
-### microk8s remove-node
+<a id="microk8s.remove-node"> </a>
+### microk8s.remove-node
 
-**Usage:** `microk8s remove-node address`
+**Usage:** `microk8s.remove-node address`
 
 **Options:**
 
@@ -349,21 +350,21 @@ Removes a specified node from the current cluster. The node should be
 identified by hostname/IP address by which it is known to the cluster. To
 retrieve this information you can run:
 
-`microk8s kubectl get nodes`
+`microk8s.kubectl get nodes`
 
 This command only works on the master node of the cluster. To remove the local
-node from a remote cluster, see [`microk8s leave`](#microk8s leave).
+node from a remote cluster, see [`microk8s.leave`](#microk8s.leave).
 
 **Examples:**
 
-`microk8s remove-node 10.128.63.163`
+`microk8s.remove-node 10.128.63.163`
 
 ---
 
-<a id="microk8s-reset"> </a>
-### microk8s reset
+<a id="microk8s.reset"> </a>
+### microk8s.reset
 
-**Usage:** `microk8s reset [--destroy-storage]`
+**Usage:** `microk8s.reset [--destroy-storage]`
 
 **Options:**
 
@@ -381,7 +382,7 @@ wihout having to reinstall anything.
 
 **Examples:**
 
-`microk8s reset`
+`microk8s.reset`
 
 ...will result in output similar to:
 
@@ -399,20 +400,20 @@ service "kubernetes" deleted
 
 ---
 
-<a id="microk8s-start"> </a>
-### microk8s start
+<a id="microk8s.start"> </a>
+### microk8s.start
 
-**Usage:** `microk8s start`
+**Usage:** `microk8s.start`
 
 **Options:**
 
 **Description:**
 Will start MicroK8s, if the MicorK8s node has previously been halted
-with `microk8s stop`.
+with `microk8s.stop`.
 
 **Examples:**
 
-`microk8s start`
+`microk8s.start`
 
 ...will result in output similar to:
 
@@ -424,10 +425,10 @@ node/ubuntu1804 already uncordoned
 
 ---
 
-<a id="microk8s-status"> </a>
-### microk8s status
+<a id="microk8s.status"> </a>
+### microk8s.status
 
-**Usage:** `microk8s status`
+**Usage:** `microk8s.status`
 
 **Options:**
 
@@ -438,7 +439,7 @@ which ones are enabled/disabled.
 
 **Examples:**
 
-`microk8s status`
+`microk8s.status`
 
 ...will result in output similar to:
 
@@ -471,10 +472,10 @@ addons:
 
 ---
 
-<a id="microk8s-stop"> </a>
-### microk8s stop
+<a id="microk8s.stop"> </a>
+### microk8s.stop
 
-**Usage:** `microk8s stop`
+**Usage:** `microk8s.stop`
 
 **Options:**
 
@@ -483,7 +484,7 @@ Halts the current MicroK8s node.
 
 **Examples:**
 
-`microk8s stop`
+`microk8s.stop`
 
 ...will result in output describing the shutdown process.
 
@@ -497,9 +498,9 @@ Halts the current MicroK8s node.
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
-    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/commands.md" class="p-notification__action">edit this page</a>
-    or
+    We appreciate your feedback on the docs. You can 
+    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/commands.md" class="p-notification__action">edit this page</a> 
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,13 +48,9 @@ MicroK8s will install a minimal, lightweight Kubernetes you can run and use on p
         <div class="p-stepped-list__content">
 
 MicroK8s creates a group to enable seamless usage of commands which require admin privilege. To add your current user
-to the group and gain access to the <code>.kube</code> caching directory, run the following two commands:
+to the group, run the following:
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="sudo usermod -a -G microk8s $USER" readonly="readonly">
-            <button class="p-code-copyable__action">Copy to clipboard</button>
-          </div>
-          <div class="p-code-copyable">
-            <input class="p-code-copyable__input" value="sudo chown -f -R $USER ~/.kube" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           You will also need to re-enter the session for the group update to take place:
@@ -71,24 +67,24 @@ to the group and gain access to the <code>.kube</code> caching directory, run th
 MicroK8s has a built-in command to display its status. During installation you
 can use the <code>--wait-ready</code> flag to wait for the Kubernetes services to initialise:
           <div class="p-code-copyable">
-            <input class="p-code-copyable__input" value="microk8s status --wait-ready" readonly="readonly">
+            <input class="p-code-copyable__input" value="microk8s.status --wait-ready" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </div>
       </li>
-      <a id="rejoin"> </a>
+
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title"><span class="p-stepped-list__bullet">4</span>Access Kubernetes</h3>
         <div class="p-stepped-list__content">
 <p>MicroK8s bundles its own version of <code>kubectl</code> for accessing Kubernetes. Use it to run
 commands to monitor and control your Kubernetes. For example, to view your node:</p>
           <div class="p-code-copyable">
-            <input class="p-code-copyable__input" value="microk8s kubectl get nodes" readonly="readonly">
+            <input class="p-code-copyable__input" value="microk8s.kubectl get nodes" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
 <p>&hellip; or to see the running services: </p>
 <div class="p-code-copyable">
-  <input class="p-code-copyable__input" value="microk8s kubectl get services" readonly="readonly">
+  <input class="p-code-copyable__input" value="microk8s.kubectl get services" readonly="readonly">
   <button class="p-code-copyable__action">Copy to clipboard</button>
 </div>
 <p>
@@ -97,7 +93,7 @@ commands to monitor and control your Kubernetes. For example, to view your node:
   add an alias (append to <code>~/.bash_aliases</code>) like this:
   </p>
   <div class="p-code-copyable">
-    <input class="p-code-copyable__input" value="alias kubectl='microk8s kubectl'" readonly="readonly">
+    <input class="p-code-copyable__input" value="alias kubectl='microk8s.kubectl'" readonly="readonly">
     <button class="p-code-copyable__action">Copy to clipboard</button>
   </div>
 
@@ -111,13 +107,13 @@ commands to monitor and control your Kubernetes. For example, to view your node:
           the <code>kubectl</code> command to do that as with any Kuberenetes. Try
           installing a demo app:</p>
           <div class="p-code-copyable">
-            <input class="p-code-copyable__input" value="microk8s kubectl create deployment kubernetes-bootcamp --image=gcr.io/google-samples/kubernetes-bootcamp:v1" readonly="readonly">
+            <input class="p-code-copyable__input" value="microk8s.kubectl create deployment kubernetes-bootcamp --image=gcr.io/google-samples/kubernetes-bootcamp:v1" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>It may take a minute or two to install, but you can check the status:</p>
 
           <div class="p-code-copyable">
-            <input class="p-code-copyable__input" value="microk8s kubectl get pods" readonly="readonly">
+            <input class="p-code-copyable__input" value="microk8s.kubectl get pods" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </div>
@@ -132,7 +128,7 @@ MicroK8s uses the minimum of components for a pure, lightweight Kubernetes. Howe
 <p>
 To start it is recommended to add DNS management to facilitate communication between services. For applications which need storage, the 'storage' add-on provides directory space on the host. These are easy to set up:</p>
           <div class="p-code-copyable">
-            <input class="p-code-copyable__input" value="microk8s enable dns storage" readonly="readonly">
+            <input class="p-code-copyable__input" value="microk8s.enable dns storage" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>
@@ -147,12 +143,12 @@ To start it is recommended to add DNS management to facilitate communication bet
         <div class="p-stepped-list__content">
           <p>MicroK8s will continue running until you decide to stop it. You can stop and start MicroK8s with these simple commands:</p>
           <div class="p-code-copyable">
-            <input class="p-code-copyable__input" value="microk8s stop" readonly="readonly">
+            <input class="p-code-copyable__input" value="microk8s.stop" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>... will stop MicroK8s and its services. You can start again any time by running:</p>
           <div class="p-code-copyable">
-            <input class="p-code-copyable__input" value="microk8s start" readonly="readonly">
+            <input class="p-code-copyable__input" value="microk8s.start" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </div>

--- a/docs/install-alternatives.md
+++ b/docs/install-alternatives.md
@@ -13,84 +13,32 @@ notes below.
 <a id="windows"> </a>
 ## Windows 10
 
-From 1.18, MicroK8s now has an official Windows installer, which is the
-recommended way to install MicroK8s
+Although Windows 10 now has some very useful features, such as the ability to
+install [Ubuntu as an app][ubuntu-app], the integration of WSL2 still
+doesn't provide all the Ubuntu functionality required to make MicroK8s run
+smoothly out-of-the-box.
 
-1.  **Download the installer**
+If you wish to experiment with running MicroK8s semi-natively, take a look at
+this [discourse post on WSL2][windows-post].
 
-    The Windows installer is available on the MicroK8s GitHub page.
-    [Download it here](https://github.com/ubuntu/microk8s/releases/download/installer-v1.0.0/microk8s-installer.exe)
+For now, the best way to run MicroK8s on Windows is with virtualisation.
+MicroK8s will install without problems on Ubuntu running on number of different
+VMs, including [VirtualBox](https://www.virtualbox.org/).
 
-1.  **Run the installer**
-
-    Once the installer is downloaded, run it to begin installation.
-
-    You will be asked a few questions as usual when installing software. Some
-    things to note:
-
-    ![](https://assets.ubuntu.com/v1/141d9f8b-winmk8s-01.png)
-
-    We recommend installing for 'All users'
-
-    ![](https://assets.ubuntu.com/v1/c7d0a5a7-winmk8s-03.png)
-
-    The installer also requires the Ubuntu VM system, [Multipass][], to be
-    installed. This will be done automatically when you click 'Yes' here.
-
-1.  **Open the command line:**
-
-    Use PowerShell or the standard Windows 'cmd' to open a commandline.
-
-    ![](https://assets.ubuntu.com/v1/a5fe14a5-winmk8s-04.png)
-
-1.  **Check MicroK8s is running**
-
-    Run the command:
-
-    ```
-    microk8s status --wait-ready
-    ```
-
-1.  **Explore what you can do!**
-
-    Congrats! MicroK8s is now running on your Windows machine and is ready
-    for you to explore and use Kubernetes. See the
-    [main install](/docs/index#rejoin) page for your next steps!
+The recommended way to run MicroK8s in a VM on Windows 10 is to use
+[multipass][]. The Windows installer is available for
+[download here][multipass-install], and the notes for installing MicroK8s on
+multipass [here](#multipass).
 
 <a id="macos"> </a>
 ## macOS
 
-The recommended way to install MicroK8s on MacOS is with Homebrew
+As with Windows, the recommended way to run MicroK8s on macOS is to use
+[multipass][], although it is possible to run under other VMs.
 
-1.  **Install Homebrew**
-
-    Open a terminal and run the installer:
-
-    ```
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-    ```
-
-1.  **Install MicroK8s**
-
-    Run the command:
-
-    ```
-    brew install ubuntu/microk8s/microk8s
-    microk8s install
-    ```
-
-    [![asciicast](https://asciinema.org/a/IWhwnidik9xaC2YHfjBUIsLin.svg)](https://asciinema.org/a/IWhwnidik9xaC2YHfjBUIsLin)
-
-1.  **Wait for MicroK8s to start**
-
-    ```
-    microk8s status --wait-ready
-    ```
-
-1.  **Congrats!**
-
-    MicroK8s is now running! Continue to explore by following the
-    _Getting Started_ instructions [here](/docs/index#rejoin)
+There is an installer for multipass available on the
+[multipass site][multipass-install]. See the notes for running MicroK8s on
+multipass below.
 
 
 <a id="multipass"> </a>
@@ -187,7 +135,7 @@ you can fix this:
 1.  Stop microk8s:
 
     ```
-    microk8s stop
+    microk8s.stop
     ```
 
 1.  Remove old state of containerd:
@@ -208,7 +156,7 @@ you can fix this:
 1.  Restart microk8s:
 
     ```
-    microk8s start
+    microk8s.start
     ```
 
 ## Offline deployment

--- a/docs/install-proxy.md
+++ b/docs/install-proxy.md
@@ -6,7 +6,7 @@ permalink: /docs/install-proxy
 
 # Install behind a proxy
 
-To let MicroK8s use a proxy we need to enter the proxy details in
+To let MicroK8s use a proxy we need to enter the proxy details in 
 `${SNAP_DATA}/args/containerd-env` (normally `/var/snap/microk8s/current/args/containerd-env`). The `containerd-env` file holds the environment variables containerd runs with. Setting the `HTTPS_PROXY` to your proxy endpoint enables containerd to fetch conatiner images from the web. Here is an example where `HTTPS_PROXY` is set to `https://squid.internal:3128`:
 
 ```
@@ -21,16 +21,16 @@ ulimit -l 16384 || true
 For the changes to take effect we need to restart MicroK8s:
 
 ```bash
-microk8s stop
-microk8s start
+microk8s.stop
+microk8s.start
 ```
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
+    We appreciate your feedback on the docs. You can 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/install-proxy.md" class="p-notification__action">edit this page</a> 
-    or
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -55,10 +55,10 @@ The authentication [strategies](https://kubernetes.io/docs/reference/access-auth
  - Static Token File with tokens in `/var/snap/microk8s/current/credentials/known_tokens.csv`, and
  - X509 Client Certs with the client CA file set to `/var/snap/microk8s/current/certs/ca.crt`.
  Under `/var/snap/microk8s/current/credentials/` you can find the `client.config` kubeconfig file
- used by `microk8s kubectl`.
+ used by `microk8s.kubectl`.
 
 By default all authenticated requests are authorized as the api-server runs with
-`--authorization-mode=AlwaysAllow`. Turning on [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) is done through `microk8s enable rbac`.
+`--authorization-mode=AlwaysAllow`. Turning on [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) is done through `microk8s.enable rbac`.
 
 
 ## References
@@ -72,9 +72,9 @@ By default all authenticated requests are authorized as the api-server runs with
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
+    We appreciate your feedback on the docs. You can 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/ports.md" class="p-notification__action">edit this page</a> 
-    or
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/docs/registry-built-in.md
+++ b/docs/registry-built-in.md
@@ -16,7 +16,7 @@ access to it.
 You can install the registry with:
 
 ```bash
-microk8s enable registry
+microk8s.enable registry
 ```
 
 The add-on registry is backed up by a `20Gi` persistent volume is claimed for
@@ -75,7 +75,7 @@ The new configuration should be loaded with a Docker daemon restart:
 sudo systemctl restart docker
 ```
 
-At this point we are ready to `microk8s kubectl apply -f` a deployment with our
+At this point we are ready to `microk8s.kubectl apply -f` a deployment with our
 image:
 
 ```yaml
@@ -181,9 +181,9 @@ runs inside the VM so it is on `localhost:32000`.
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
+    We appreciate your feedback on the docs. You can 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/registry-built-in.md" class="p-notification__action">edit this page</a> 
-    or
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/docs/registry-images.md
+++ b/docs/registry-images.md
@@ -72,7 +72,7 @@ Docker daemon and "inject" it into the  MicroK8s image cache like this:
 
 ```bash
 docker save mynginx > myimage.tar
-microk8s ctr image import myimage.tar
+microk8s.ctr image import myimage.tar
 ```
 
 Note that when we import the image to MicroK8s we do so under the `k8s.io`
@@ -81,10 +81,10 @@ namespace.
 Now we can list the images present in MicroK8s:
 
 ```bash
-microk8s ctr images ls
+microk8s.ctr images ls
 ```
 
-At this point we are ready to `microk8s kubectl apply -f` a deployment with
+At this point we are ready to `microk8s.kubectl apply -f` a deployment with
 this image:
 
 ```yaml
@@ -119,9 +119,9 @@ tag so make sure you avoid it.
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
+    We appreciate your feedback on the docs. You can 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/registry-images.md" class="p-notification__action">edit this page</a> 
-    or
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/docs/registry-private.md
+++ b/docs/registry-private.md
@@ -63,13 +63,13 @@ See the full file [here](containerd-template.toml).
 Restart MicroK8s to have the new configuration loaded:
 
 ```bash
-microk8s stop
+microk8s.stop
 ```
 
 Allow a few seconds for the service to close fully before starting again:
 
 ```bash
-microk8s start
+microk8s.start
 ```
 
 The image can now be deployed with:
@@ -116,7 +116,7 @@ with Kubernetes.
     users should be aware of the secure registry and the credentials needed to
     access it. As shown above, configuring containerd involves editing
     `/var/snap/microk8s/current/args/containerd-template.toml` and reloading
-    the new configuration via a `microk8s stop`, `microk8s start` cycle.
+    the new configuration via a `microk8s.stop`, `microk8s.start` cycle.
 
 <!-- LINKS -->
 
@@ -124,9 +124,9 @@ with Kubernetes.
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
+    We appreciate your feedback on the docs. You can 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/registry-private.md" class="p-notification__action">edit this page</a> 
-    or
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/docs/registry-public.md
+++ b/docs/registry-public.md
@@ -57,7 +57,7 @@ Now that the image is tagged correctly, it can be pushed to the registry:
 docker push kjackal/mynginx
 ```
 
-At this point we are ready to `microk8s kubectl apply -f` a deployment with our
+At this point we are ready to `microk8s.kubectl apply -f` a deployment with our
 image:
 
 ```yaml
@@ -88,9 +88,9 @@ search for the image in its default registry, `docker.io`.
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
+    We appreciate your feedback on the docs. You can 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/registry-public.md" class="p-notification__action">edit this page</a> 
-    or
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,7 +20,6 @@ snap install microk8s --classic --channel=1.18/stable
 
 Most important updates since the last release:
 
--   Installers for MacOS and Windows
 -   Kubeflow 1.0 addon
 -   Added new snap interface enabling other snaps to detect MicroK8s’ presence.
 -   CoreDNS addon upgraded to v1.6.6, thank you [@balchua][]

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,7 +18,7 @@ logs.
 First determine the resource identifier for the pod:
 
 ```bash
-microk8s kubectl get pods
+microk8s.kubectl get pods
 ```
 This will list the currently available pods, for example:
 
@@ -31,7 +31,7 @@ You can then use `kubectl` to view the log. For example, for the simple redis
 pod above:
 
 ```bash
-microk8s kubectl logs mk8s-redis-7647889b6d-vjwqm
+microk8s.kubectl logs mk8s-redis-7647889b6d-vjwqm
 ```
 
 ### Examining the configuration
@@ -56,7 +56,7 @@ To run the inspection tool, enter the command (admin privilege is required
 to collect all the data):
 
 ```bash
-sudo microk8s inspect
+sudo microk8s.inspect
 ```
 
 You should see output similar to the following:
@@ -127,7 +127,7 @@ can be viewed to get a detailed look at every aspect of the system.
 
    <p>The MicroK8s inspect command can be used to check the firewall configuration:</p>
 
-   <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>   microk8s inspect
+   <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>   microk8s.inspect
    </code></pre></div></div>
 
    <p>A warning will be shown if the firewall is not forwarding traffic.</p>
@@ -177,7 +177,7 @@ If you cannot solve your issue and believe the fault may lie in MicroK8s,
 please [file an issue on the project repository][bugs].
 
 To help us deal effectively with issues, it is incredibly useful to include
-the report obtained from [`microk8s inspect`](#inspect), as well as any
+the report obtained from [`microk8s.inspect`](#inspect), as well as any
 additional logs, and a summary of the issue.
 
 <!--LINKS-->
@@ -186,9 +186,9 @@ additional logs, and a summary of the issue.
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
-    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/troubleshooting.md" class="p-notification__action">edit this page</a>
-    or
+    We appreciate your feedback on the docs. You can 
+    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/troubleshooting.md" class="p-notification__action">edit this page</a> 
+    or 
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>


### PR DESCRIPTION
## Done

- removes all the 'microk8s *' commands in favour of 'microk8s.*' as these won't work without installer
- removes note about Win/Mac installers from release notes
- reverts the Mac and Windows install section **in the docs** to use multipass


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
