### PR TITLE
revert install instructions for macOS/Windows

### DIFF
--- a/docs/install-alternatives.md
+++ b/docs/install-alternatives.md
@@ -13,84 +13,48 @@ notes below.
 <a id="windows"> </a>
 ## Windows 10
 
-From 1.18, MicroK8s now has an official Windows installer, which is the
-recommended way to install MicroK8s
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    Installing MicroK8s with Multipass requires Windows 10 Professional or
+    Windows 10 Enterprise, as it relies on the <em>Hyper-V</em> hypervisor. It
+    will also require at least 4GB of available RAM and 40GB of storage.
+  </p>
+</div>
 
-1.  **Download the installer**
+Although Windows 10 now has some very useful features, such as the ability to
+install [Ubuntu as an app][ubuntu-app], the integration of WSL2 still
+doesn't provide all the Ubuntu functionality required to make MicroK8s run
+smoothly out-of-the-box.
 
-    The Windows installer is available on the MicroK8s GitHub page.
-    [Download it here](https://github.com/ubuntu/microk8s/releases/download/installer-v1.0.0/microk8s-installer.exe)
+If you wish to experiment with running MicroK8s semi-natively, take a look at
+this [discourse post on WSL2][windows-post].
 
-1.  **Run the installer**
+For now, the best way to run MicroK8s on Windows is with virtualisation.
+MicroK8s will install without problems on Ubuntu running on number of different
+VMs, including [VirtualBox](https://www.virtualbox.org/).
 
-    Once the installer is downloaded, run it to begin installation.
-
-    You will be asked a few questions as usual when installing software. Some
-    things to note:
-
-    ![](https://assets.ubuntu.com/v1/141d9f8b-winmk8s-01.png)
-
-    We recommend installing for 'All users'
-
-    ![](https://assets.ubuntu.com/v1/c7d0a5a7-winmk8s-03.png)
-
-    The installer also requires the Ubuntu VM system, [Multipass][], to be
-    installed. This will be done automatically when you click 'Yes' here.
-
-1.  **Open the command line:**
-
-    Use PowerShell or the standard Windows 'cmd' to open a commandline.
-
-    ![](https://assets.ubuntu.com/v1/a5fe14a5-winmk8s-04.png)
-
-1.  **Check MicroK8s is running**
-
-    Run the command:
-
-    ```
-    microk8s status --wait-ready
-    ```
-
-1.  **Explore what you can do!**
-
-    Congrats! MicroK8s is now running on your Windows machine and is ready
-    for you to explore and use Kubernetes. See the
-    [main install](/docs/index#rejoin) page for your next steps!
+The recommended way to run MicroK8s in a VM on Windows 10 is to use
+[multipass][]. The Windows installer is available for
+[download here][multipass-install], and the notes for installing MicroK8s on
+multipass [here](#multipass).
 
 <a id="macos"> </a>
 ## macOS
 
-The recommended way to install MicroK8s on MacOS is with Homebrew
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    Installing MicroK8s with Multipass requires <em>macOS Yosemite</em>, version
+    10.10.3 or later installed on hardware from 2010 onwards. It
+    will also require at least 4GB of available RAM and 40GB of storage.
+  </p>
+</div>
 
-1.  **Install Homebrew**
+As with Windows, the recommended way to run MicroK8s on macOS is to use
+[multipass][], although it is possible to run under other VMs.
 
-    Open a terminal and run the installer:
-
-    ```
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-    ```
-
-1.  **Install MicroK8s**
-
-    Run the command:
-
-    ```
-    brew install ubuntu/microk8s/microk8s
-    microk8s install
-    ```
-
-    [![asciicast](https://asciinema.org/a/IWhwnidik9xaC2YHfjBUIsLin.svg)](https://asciinema.org/a/IWhwnidik9xaC2YHfjBUIsLin)
-
-1.  **Wait for MicroK8s to start**
-
-    ```
-    microk8s status --wait-ready
-    ```
-
-1.  **Congrats!**
-
-    MicroK8s is now running! Continue to explore by following the
-    _Getting Started_ instructions [here](/docs/index#rejoin)
+There is an installer for multipass available on the
+[multipass site][multipass-install]. See the notes for running MicroK8s on
+multipass below.
 
 
 <a id="multipass"> </a>
@@ -129,7 +93,7 @@ multipass shell microk8s-vm
 Then install the  MicroK8s snap and configure the network:
 
 ```bash
-sudo snap install microk8s --classic --channel=1.17/stable
+sudo snap install microk8s --classic --channel=1.18/stable
 sudo iptables -P FORWARD ACCEPT
 ```
 

--- a/index.html
+++ b/index.html
@@ -268,32 +268,47 @@ layout: base
           </noscript>
           <ol class="p-stepped-list u-no-margin--left">
             <li class="p-stepped-list__item">
-              <h3 class="p-stepped-list__title">Download the installer for Windows</h3>
+              <h3 class="p-stepped-list__title">Install Multipass for Windows</h3>
 
-              <p class="p-stepped-list__content u-stepped-list-margin">
-                <a href="https://github.com/ubuntu/microk8s/releases/download/installer-v1.0.0/microk8s-installer.exe" class="p-button--positive">
-                  <span class="p-link--external">Download MicroK8s for Windows</span>
-                </a>
-              </p>
+                <p class="p-stepped-list__content u-stepped-list-margin">
+                  <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--positive js-download" data-os="win-win">
+                    <span class="p-link--external">Download Multipass for Windows</span>
+                  </a>
+                </p>
             </li>
 
             <li class="p-stepped-list__item">
-              <h3 class="p-stepped-list__title">Run the Installer</h3>
+              <h3 class="p-stepped-list__title">Launch a Multipass instance</h3>
 
-              <img src="https://assets.ubuntu.com/v1/141d9f8b-winmk8s-01.png">
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" value="multipass launch --name microk8s-vm --mem 4G --disk 40G" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
             </li>
 
             <li class="p-stepped-list__item">
-              <h3 class="p-stepped-list__title">Open a command line</h3>
+              <h3 class="p-stepped-list__title">Enter the VM instance</h3>
 
-              <img src="https://assets.ubuntu.com/v1/a5fe14a5-winmk8s-04.png">
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" aria-label="multipass shell microk8s-vm" value="multipass shell microk8s-vm" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
+            </li>
+
+            <li class="p-stepped-list__item">
+              <h3 class="p-stepped-list__title">Install the microk8s snap</h3>
+
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic" value="sudo snap install microk8s --classic" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
             </li>
 
             <li class="p-stepped-list__item">
               <h3 class="p-stepped-list__title">Check the status</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="microk8s status --wait-ready" value="microk8s status --wait-ready" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="sudo microk8s status --wait-ready" value="sudo microk8s status --wait-ready" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
             </li>
@@ -302,7 +317,7 @@ layout: base
               <h3 class="p-stepped-list__title">Turn on standard services</h3>
 
               <div class="p-code-copyable u-stepped-list-margin">
-                <input class="p-code-copyable__input" aria-label="microk8s enable dns dashboard registry istio" value="microk8s enable dns dashboard registry" readonly="readonly">
+                <input class="p-code-copyable__input" aria-label="sudo microk8s enable dns dashboard registry istio" value="sudo microk8s enable dns dashboard registry" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
 
@@ -321,58 +336,63 @@ layout: base
           </noscript>
           <ol class="p-stepped-list u-no-margin--left">
             <li class="p-stepped-list__item">
-              <h3 class="p-stepped-list__title">Install Homebrew</h3>
-              <p> You can open a terminal and copy in the command below, or
-                visit <a href="http://brew.sh"> the Homebrew website</a> for
-                alternatives. </p>
-                <div class="p-code-copyable u-stepped-list-margin">
+              <h3 class="p-stepped-list__title">Install Multipass for macOS</h3>
 
-                  <input class="p-code-copyable__input" value='/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-                  " readonly="readonly'>
-                  <button class="p-code-copyable__action">Copy to clipboard</button>
-                </div>
-              </li>
+              <p class="p-stepped-list__content u-stepped-list-margin">
+                <a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--positive js-download" data-os="mac">
+                  <span class="p-link--external">Download Multipass for macOS</span>
+                </a>
+              </p>
+            </li>
 
-              <li class="p-stepped-list__item">
-                <h3 class="p-stepped-list__title">Install MicroK8s</h3>
+            <li class="p-stepped-list__item">
+              <h3 class="p-stepped-list__title">Launch a Multipass instance</h3>
 
-                <div class="p-code-copyable u-stepped-list-margin">
-                  <input class="p-code-copyable__input" value="brew install ubuntu/microk8s/microk8s" readonly="readonly">
-                  <button class="p-code-copyable__action">Copy to clipboard</button>
-                </div>
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" value="multipass launch --name microk8s-vm --mem 4G --disk 40G" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
+            </li>
 
-              </li>
-              <li class="p-stepped-list__item">
-                <h3 class="p-stepped-list__title">Start MicroK8s</h3>
+            <li class="p-stepped-list__item">
+              <h3 class="p-stepped-list__title">Enter the VM instance</h3>
 
-                <div class="p-code-copyable u-stepped-list-margin">
-                  <input class="p-code-copyable__input" value="microk8s install" readonly="readonly">
-                  <button class="p-code-copyable__action">Copy to clipboard</button>
-                </div>
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" aria-label="multipass shell microk8s-vm" value="multipass shell microk8s-vm" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
+            </li>
 
-              </li>
+            <li class="p-stepped-list__item">
+              <h3 class="p-stepped-list__title">Install the microk8s snap</h3>
 
-              <li class="p-stepped-list__item">
-                <h3 class="p-stepped-list__title">Check the status</h3>
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" aria-label="sudo snap install microk8s --classic" value="sudo snap install microk8s --classic" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
+            </li>
 
-                <div class="p-code-copyable u-stepped-list-margin">
-                  <input class="p-code-copyable__input" aria-label="microk8s status --wait-ready" value="microk8s status --wait-ready" readonly="readonly">
-                  <button class="p-code-copyable__action">Copy to clipboard</button>
-                </div>
-              </li>
+            <li class="p-stepped-list__item">
+              <h3 class="p-stepped-list__title">Check the status</h3>
 
-              <li class="p-stepped-list__item">
-                <h3 class="p-stepped-list__title">Turn on standard services</h3>
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" aria-label="sudo microk8s status --wait-ready" value="sudo microk8s status --wait-ready" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
+            </li>
 
-                <div class="p-code-copyable u-stepped-list-margin">
-                  <input class="p-code-copyable__input" aria-label="microk8s enable dns dashboard registry istio" value="microk8s enable dns dashboard registry" readonly="readonly">
-                  <button class="p-code-copyable__action">Copy to clipboard</button>
-                </div>
+            <li class="p-stepped-list__item">
+              <h3 class="p-stepped-list__title">Turn on standard services</h3>
 
-                <p class="p-stepped-list__content u-stepped-list-margin">
-                  Similarly, <code>microk8s disable</code> turns off a service. Try <code>microk8s enable --help</code> for a list of available services built in.
-                </p>
-              </li>
+              <div class="p-code-copyable u-stepped-list-margin">
+                <input class="p-code-copyable__input" aria-label="sudo microk8s enable dns dashboard registry" value="sudo microk8s enable dns dashboard registry" readonly="readonly">
+                <button class="p-code-copyable__action">Copy to clipboard</button>
+              </div>
+
+              <p class="p-stepped-list__content u-stepped-list-margin">
+                Similarly, <code>microk8s disable</code> turns off a service. Try <code>microk8s enable --help</code> for a list of available services built in.
+              </p>
+            </li>
 
             </ol>
           </div>


### PR DESCRIPTION
## Done

- Revert to Multipass for Windows on Index page
- Revert to Multipass for macOS on index page
- revert to Multipass for alternative-install page in docs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)