### PR TITLE
add back installer instructions for docs

### DIFF
--- a/docs/install-alternatives.md
+++ b/docs/install-alternatives.md
@@ -15,28 +15,66 @@ notes below.
 
 <div class="p-notification--information">
   <p class="p-notification__response">
-    Installing MicroK8s with Multipass requires Windows 10 Professional or
-    Windows 10 Enterprise, as it relies on the <em>Hyper-V</em> hypervisor. It
+    Installing MicroK8s with Multipass requires Windows 10 Professional,
+    Windows 10 Education or Windows 10 Enterprise, as it relies on the
+    <em>Hyper-V</em> hypervisor. It
     will also require at least 4GB of available RAM and 40GB of storage.
   </p>
 </div>
 
-Although Windows 10 now has some very useful features, such as the ability to
-install [Ubuntu as an app][ubuntu-app], the integration of WSL2 still
-doesn't provide all the Ubuntu functionality required to make MicroK8s run
-smoothly out-of-the-box.
+From 1.18, MicroK8s now has an official Windows installer, which is the
+recommended way to install MicroK8s
 
-If you wish to experiment with running MicroK8s semi-natively, take a look at
-this [discourse post on WSL2][windows-post].
+1. **Enable Hyper-V**
+    If you have not previously done so, you should enable the Hyper-V
+    hypervisor feature in Windows 10. To do so, please follow the
+    instructions on the [MicroSoft website][hyper-v].
 
-For now, the best way to run MicroK8s on Windows is with virtualisation.
-MicroK8s will install without problems on Ubuntu running on number of different
-VMs, including [VirtualBox](https://www.virtualbox.org/).
+1.  **Download the installer**
 
-The recommended way to run MicroK8s in a VM on Windows 10 is to use
-[multipass][]. The Windows installer is available for
-[download here][multipass-install], and the notes for installing MicroK8s on
-multipass [here](#multipass).
+    The Windows installer is available on the MicroK8s GitHub page.
+    [Download it here](https://github.com/ubuntu/microk8s/releases/download/installer-v1.0.0/microk8s-installer.exe)
+
+1.  **Run the installer**
+
+    Once the installer is downloaded, run it to begin installation.
+
+    You will be asked a few questions as usual when installing software. Some
+    things to note:
+
+    ![](https://assets.ubuntu.com/v1/141d9f8b-winmk8s-01.png)
+
+    We recommend installing for 'All users'
+
+    ![](https://assets.ubuntu.com/v1/c7d0a5a7-winmk8s-03.png)
+
+    The installer also requires the Ubuntu VM system, [Multipass][], to be
+    installed. This will be done automatically when you click 'Yes' here.
+
+1.  **Open the command line:**
+
+    Use PowerShell or the standard Windows 'cmd' to open a commandline.
+
+    ![](https://assets.ubuntu.com/v1/a5fe14a5-winmk8s-04.png)
+
+1.  **Check MicroK8s is running**
+
+    Run the command:
+
+    ```
+    microk8s status --wait-ready
+    ```
+
+1.  **Explore what you can do!**
+
+    Congrats! MicroK8s is now running on your Windows machine and is ready
+    for you to explore and use Kubernetes. See the
+    [main install](/docs/index#rejoin) page for your next steps!
+
+### Uninstalling
+
+To uninstall MicroK8s on Windows 10, please [follow this guide][uninstall].
+
 
 <a id="macos"> </a>
 ## macOS
@@ -49,13 +87,43 @@ multipass [here](#multipass).
   </p>
 </div>
 
-As with Windows, the recommended way to run MicroK8s on macOS is to use
-[multipass][], although it is possible to run under other VMs.
+The recommended way to install MicroK8s on MacOS is with Homebrew
 
-There is an installer for multipass available on the
-[multipass site][multipass-install]. See the notes for running MicroK8s on
-multipass below.
+1.  **Install Homebrew**
 
+    Open a terminal and run the installer:
+
+    ```
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+    ```
+
+1.  **Install MicroK8s**
+
+    Run the command:
+
+    ```
+    brew install ubuntu/microk8s/microk8s
+    microk8s install
+    ```
+
+    [![asciicast](https://asciinema.org/a/IWhwnidik9xaC2YHfjBUIsLin.svg)](https://asciinema.org/a/IWhwnidik9xaC2YHfjBUIsLin)
+
+1.  **Wait for MicroK8s to start**
+
+    ```
+    microk8s status --wait-ready
+    ```
+
+1.  **Congrats!**
+
+    MicroK8s is now running! Continue to explore by following the
+    _Getting Started_ instructions [here](/docs/index#rejoin)
+
+
+
+### Uninstalling
+
+To uninstall MicroK8s on Windows 10, please [follow this guide][uninstall].
 
 <a id="multipass"> </a>
 ## multipass
@@ -218,18 +286,12 @@ For an example, see this [answer on askubuntu][askubuntu].
 
 <!-- LINKS -->
 
+[uninstall]: /docs/uninstall-alternatives
 [ubuntu-app]: https://www.microsoft.com/en-us/p/ubuntu/9nblggh4msv6
 [windows-post]: https://discourse.ubuntu.com/t/using-snapd-in-wsl2/12113
 [multipass]: https://multipass.run/
 [multipass-install]: https://multipass.run/#install
 [askubuntu]: https://askubuntu.com/questions/993139/how-to-create-a-virtual-network-interface-in-ubuntu
 [profile]: https://github.com/ubuntu/microk8s/tree/master/tests/lxc
+[hyper-v]: https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v
 <!-- FEEDBACK -->
-<div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the docs. You can
-    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/install-alternatives.md" class="p-notification__action">edit this page</a>
-    or
-    <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
-  </p>
-</div>


### PR DESCRIPTION
## Done

Adds back the instructions for Windows and Mac installers

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
