### PR TITLE
VM in windows like https://microk8s.io/

### DIFF
--- a/docs/addon-dashboard.md
+++ b/docs/addon-dashboard.md
@@ -48,25 +48,25 @@ To log in to the Dashboard, you will need the access token (unless RBAC has
 also been enabled). This is generated randomly on deployment, so we can get it with this command:
 
 ```bash
-multipass exec MicroK8sVM -- sudo /snap/bin/microk8s kubectl -n kube-system describe secret $(multipass exec MicroK8sVM -- sudo /snap/bin/microk8s kubectl -n kube-system get secret | grep default-token | cut -d " " -f1)
+multipass exec microk8s-vm -- sudo /snap/bin/microk8s kubectl -n kube-system describe secret $(multipass exec microk8s-vm -- sudo /snap/bin/microk8s kubectl -n kube-system get secret | grep default-token | cut -d " " -f1)
 ```
 
 In an RBAC enabled setup (`microk8s enable rbac`) you need to create a user with
 restricted permissions as detailed in the
 [upstream Dashboard access control documentation ][upstream-dashboard].
 
-Because you are running MicroK8s in a VM and you need to expose the Dashboard to other hosts, you
+Because you are running microk8s-vm in a VM and you need to expose the Dashboard to other hosts, you
 should also use the `--address [IP_address_that_your_browser's_host_has]` option. Set this option
 to `--address 0.0.0.0` to make the Dashboard public. For example:
 
 ```bash
-multipass exec MicroK8sVM -- sudo /snap/bin/microk8s kubectl port-forward -n kube-system service/kubernetes-dashboard 10443:443 --address 0.0.0.0
+multipass exec microk8s-vm -- sudo /snap/bin/microk8s kubectl port-forward -n kube-system service/kubernetes-dashboard 10443:443 --address 0.0.0.0
 ```
 
 Leave the proxy running and get the VM's IP address:
 
 ```bash
-multipass info MicroK8sVM | grep IPv4 | awk '{ print $2 }'
+multipass info microk8s-vm | grep IPv4 | awk '{ print $2 }'
 ```
 
 You can then access the Dashboard at `https://$CONTAINER_IP:10443`.


### PR DESCRIPTION
If the user created the VM following the guide in https://microk8s.io/ for Windows, the name of the VM will be microk8s-vm

## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
