### PR TITLE
Add host-access addon description

### DIFF
--- a/docs/addon-host-access.md
+++ b/docs/addon-host-access.md
@@ -1,0 +1,34 @@
+---
+layout: docs
+title: "Host-acces addon"
+permalink: /docs/addon-host-access
+---
+
+# Host-access addon
+
+The host-access addon enables access of services running on the host machine via a fixed IP.
+This becomes useful when your machine changes IPs as you hope through different networks. 
+
+You can install this addon with:
+
+```bash
+microk8s enable host-access
+```
+
+The local network interface created is named `lo:microk8s` and the IP assigned by default is `10.0.1.1`.
+
+We can provide a different IP with:
+```bash
+microk8s enable host-access:ip=<desired-ip>
+```
+
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the docs. You can
+    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/addon-dashboard.md" class="p-notification__action">edit this page</a>
+    or
+    <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/docs/addon-host-access.md
+++ b/docs/addon-host-access.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: "Host-acces addon"
+title: "Host-access addon"
 permalink: /docs/addon-host-access
 ---
 

--- a/docs/addon-host-access.md
+++ b/docs/addon-host-access.md
@@ -7,7 +7,7 @@ permalink: /docs/addon-host-access
 # Host-access addon
 
 The host-access addon enables access of services running on the host machine via a fixed IP.
-This becomes useful when your machine changes IPs as you hope through different networks. 
+This becomes useful when your machine changes IPs as you hop through different networks.
 
 You can install this addon with:
 
@@ -15,9 +15,9 @@ You can install this addon with:
 microk8s enable host-access
 ```
 
-The local network interface created is named `lo:microk8s` and the IP assigned by default is `10.0.1.1`.
+A new local network interface named `lo:microk8s` is created with a default IP address of `10.0.1.1`.
 
-We can provide a different IP with:
+Alternatively, provide a different IP address when enabling the addon:
 ```bash
 microk8s enable host-access:ip=<desired-ip>
 ```
@@ -27,7 +27,7 @@ microk8s enable host-access:ip=<desired-ip>
 <div class="p-notification--information">
   <p class="p-notification__response">
     We appreciate your feedback on the docs. You can
-    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/addon-dashboard.md" class="p-notification__action">edit this page</a>
+    <a href="https://github.com/canonical-web-and-design/microk8s.io/edit/master/docs/addon-host-access.md" class="p-notification__action">edit this page</a>
     or
     <a href="https://github.com/canonical-web-and-design/microk8s.io/issues/new" class="p-notification__action">file a bug here</a>.
   </p>

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -93,7 +93,7 @@ host directory.
 **metallb**: Deploys the [MetalLB Loadbalancer][metallb].  Note that currently this does not
 work under multipass on macOS, due to filtering that macOS applies to network traffic.
 
-**host-access**: Create a local interface so pods can connect to services running on the host
+[**host-access**](addon-host-access): Create a local interface so pods can connect to services running on the host
 via a fixed IP.
 
 

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -93,6 +93,10 @@ host directory.
 **metallb**: Deploys the [MetalLB Loadbalancer][metallb].  Note that currently this does not
 work under multipass on macOS, due to filtering that macOS applies to network traffic.
 
+**host-access**: Create a local interface so pods can connect to services running on the host
+via a fixed IP.
+
+
 
 <!-- LINKS -->
 


### PR DESCRIPTION
## Done

We added a new addon called host-access. This addon creates a local interface called lo:microk8s with a fixed (optionally user provided IP). In this way you can access host local services from pods while the default IP changes as you switch networks. Related PR https://github.com/ubuntu/microk8s/pull/1109

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
