### PR TITLE
Update docs with the removal of basic-auth

### DIFF
--- a/docs/ports.md
+++ b/docs/ports.md
@@ -71,9 +71,12 @@ Clients talking to the secure port of the API server (`16443`), such as the Kube
 
 The authentication [strategies](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#authentication-strategies)
  enabled by default are:
- - Static Token File with tokens in `/var/snap/microk8s/current/credentials/known_tokens.csv`,
- - X509 Client Certs with the client CA file set to `/var/snap/microk8s/current/certs/ca.crt`,
- - Static Password File with password tokens and usernames stored in `/var/snap/microk8s/current/credentials/basic_auth.csv`. This strategy is available only in releases prior to v1.19.
+ - Static Token File with tokens in `/var/snap/microk8s/current/credentials/known_tokens.csv`
+ - X509 Client Certs with the client CA file set to `/var/snap/microk8s/current/certs/ca.crt`
+ 
+ Prior to version 1.19, the following strategy is also available:
+ 
+ - Static Password File with password tokens and usernames stored in `/var/snap/microk8s/current/credentials/basic_auth.csv`
 
 Under `/var/snap/microk8s/current/credentials/` you can find the `client.config` kubeconfig file
  used by `microk8s kubectl`.

--- a/docs/ports.md
+++ b/docs/ports.md
@@ -71,10 +71,11 @@ Clients talking to the secure port of the API server (`16443`), such as the Kube
 
 The authentication [strategies](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#authentication-strategies)
  enabled by default are:
- - Static Password File, with password tokens and usernames stored in `/var/snap/microk8s/current/credentials/basic_auth.csv`
- - Static Token File with tokens in `/var/snap/microk8s/current/credentials/known_tokens.csv`, and
- - X509 Client Certs with the client CA file set to `/var/snap/microk8s/current/certs/ca.crt`.
- Under `/var/snap/microk8s/current/credentials/` you can find the `client.config` kubeconfig file
+ - Static Token File with tokens in `/var/snap/microk8s/current/credentials/known_tokens.csv`,
+ - X509 Client Certs with the client CA file set to `/var/snap/microk8s/current/certs/ca.crt`,
+ - Static Password File with password tokens and usernames stored in `/var/snap/microk8s/current/credentials/basic_auth.csv`. This strategy is available only in releases prior to v1.19.
+
+Under `/var/snap/microk8s/current/credentials/` you can find the `client.config` kubeconfig file
  used by `microk8s kubectl`.
 
 By default all authenticated requests are authorized as the api-server runs with


### PR DESCRIPTION
## Done

With v1.19 basic auth is not available anymore. We have already switched off basic auth in the latest stable installations.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
