### PR TITLE
Redirect /install.exe to /install/v2.0.0.exe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ env[23]/
 # Project-specific ignores
 static/js/dist
 
+.dotrun.json
+.venv/

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,0 +1,1 @@
+/install.exe: /install/v2.0.0.exe


### PR DESCRIPTION
From there it should be proxied to
https://github.com/ubuntu/microk8s/releases/download/installer-v2.0.0/microk8s-installer.exe

For https://github.com/canonical-web-and-design/microk8s.io/issues/280.

Twinned with https://github.com/canonical-web-and-design/deployment-configs/pull/382

QA
--

```
./run
```

Go to http://localhost:8027/install.txt, end up at http://localhost:8027/install/v2.0.0.txt