### PR TITLE
Update discourse URL to use discuss.kubernetes.io

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 canonicalwebteam.flask-base==0.6.0
-canonicalwebteam.discourse-docs==0.11.1
+canonicalwebteam.discourse-docs==0.12.0

--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -89,7 +89,7 @@
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
               </li>
               <li class="p-list__item">
-                In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+                In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.
               </li>
             </ul>
             <ul class="p-list">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -19,9 +19,8 @@ app = FlaskBase(
 )
 
 doc_parser = DocParser(
-    api=DiscourseAPI(base_url="https://discourse.ubuntu.com/"),
-    index_topic_id=15536,
-    category_id=41,
+    api=DiscourseAPI(base_url="https://discuss.kubernetes.io/"),
+    index_topic_id=11243,
     url_prefix="/docs",
 )
 if app.debug:


### PR DESCRIPTION
## Done

- Use discuss.kubernetes.io for microk8s docs: https://discuss.kubernetes.io/c/microk8s/26

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/docs
- Check that the docs work well
