### PR TITLE
Redirect for windows installer

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,1 +1,2 @@
 /install.exe: /install/v2.0.0.exe
+/microk8s-installer.exe: "https://github.com/ubuntu/microk8s/releases/download/installer-v2.0.0/microk8s-installer.exe"

--- a/templates/partial/_get-started-windows.html
+++ b/templates/partial/_get-started-windows.html
@@ -5,7 +5,7 @@
     </h3>
     <div class="p-stepped-list__content">
       <p>
-        <a class="p-button--positive" href="https://github.com/ubuntu/microk8s/releases/download/installer-v2.0.0/microk8s-installer.exe">Download MicroK8s for Windows</a>
+        <a class="p-button--positive" href="/microk8s-installer.exe">Download MicroK8s for Windows</a>
       </p>
     </div>
   </li>


### PR DESCRIPTION
## Done

- created a redirect for the Windows download and linked to that from the instructions

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Select the Windows instructions and click on the Download button, see that it points to a local file and appears to download from there

Fixes #280
