### PR TITLE
Bump exe to v2.0.1

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,2 +1,2 @@
-/install.exe: /install/v2.0.0.exe
-/microk8s-installer.exe: "https://github.com/ubuntu/microk8s/releases/download/installer-v2.0.0/microk8s-installer.exe"
+/install.exe: /install/v2.0.1.exe
+/microk8s-installer.exe: "https://github.com/ubuntu/microk8s/releases/download/installer-v2.0.1/microk8s-installer.exe"


### PR DESCRIPTION
I'm unsure where /install/v2.0.1.exe comes from but the exe has been bumped to https://github.com/ubuntu/microk8s/releases/download/installer-v2.0.1/microk8s-installer.exe