### PR TITLE
Remove datasheet from banner

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name:  PR checks
+name: PR checks
 on: pull_request
 
 env:
@@ -8,13 +8,13 @@ jobs:
   run-image:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build image
-      run: DOCKER_BUILDKIT=1 docker build --tag microk8s-io .
-    - name: Run image
-      run: |
-        docker run -d -p 80:80 --env SECRET_KEY=insecure_secret_key microk8s-io
-        sleep 1 && curl --head --fail --retry-delay 5 --retry 10 --retry-connrefused http://localhost
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: DOCKER_BUILDKIT=1 docker build --tag microk8s-io .
+      - name: Run image
+        run: |
+          docker run -d -p 80:80 --env SECRET_KEY=insecure_secret_key microk8s-io
+          sleep 1 && curl --head --fail --retry-delay 5 --retry 10 --retry-connrefused http://localhost
 
   lint-python:
     runs-on: ubuntu-latest
@@ -26,7 +26,9 @@ jobs:
         run: yarn install --immutable
 
       - name: Install python dependencies
-        run: sudo pip3 install flake8 black
+        run: |
+          python3 -m pip install --upgrade pip
+          sudo pip3 install flake8 black
 
       - name: Lint python
         run: yarn lint-python

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,6 @@
           <br />
           On cloud, clusters, workstations, IoT and Edge.
         </p>
-        <p><a href="https://assets.ubuntu.com/v1/acabb1ac-MicroK8s+Datasheet.pdf" class="p-link--external p-link--inverted">Read the datasheet</a></p>
       </div>
       <div class="col-3 u-align--center u-hide--small">
         <img src="https://assets.ubuntu.com/v1/9d785fad-Automatic+node+allocation.svg" alt="" />


### PR DESCRIPTION
## Done

- Remove datasheet from banner

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the datasheet link has been removed per the [copy doc](https://docs.google.com/document/d/1ObWmhRc4GCIhrBi8gT7yIIs0J_dn_8ravfLtcwhr3uQ/edit?ts=5f609168)


## Issue / Card

Fixes #318 
