### PR TITLE
Add new cookie policy

### DIFF
--- a/.webpack/entry.js
+++ b/.webpack/entry.js
@@ -1,4 +1,5 @@
 module.exports = {
   "global-nav": "./static/js/global-nav.js",
+  "cookie-policy": "./static/js/cookie-policy.js",
   main: ["./static/js/tabs.js", "./static/js/copytoclipboard.js"],
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test-js": "jest"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "3.0.2",
+    "@canonical/cookie-policy": "3.0.3",
     "@canonical/global-nav": "2.4.3",
     "autoprefixer": "9.8.6",
     "babel-eslint": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test-js": "jest"
   },
   "dependencies": {
+    "@canonical/cookie-policy": "3.0.2",
     "@canonical/global-nav": "2.4.3",
     "autoprefixer": "9.8.6",
     "babel-eslint": "10.1.0",

--- a/static/js/cookie-policy.js
+++ b/static/js/cookie-policy.js
@@ -1,0 +1,2 @@
+import { cookiePolicy } from "@canonical/cookie-policy";
+cookiePolicy();

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -7,6 +7,9 @@
 
 @include microk8s-l-docs;
 
+// import cookie policy
+@import "@canonical/cookie-policy/build/css/cookie-policy";
+
 // import additional styles
 @import "sidebar";
 @import "blockquote";

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -92,6 +92,7 @@
 
   <script src="{{ versioned_static('js/dist/global-nav.js') }}"></script>
   <script src="{{ versioned_static('js/dist/main.js') }}"></script>
+  <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
 
 </body>
 

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -10,6 +10,9 @@
             <a href="https://www.ubuntu.com/legal">Legal information</a>
           </li>
           <li class="p-inline-list__item">
+            <a href="" class="js-revoke-cookie-manager">Manage your tracker settings</a>
+          </li>
+          <li class="p-inline-list__item">
             <a class="p-footer__link" href="https://github.com/canonical-websites/microk8s.io/issues/new">Report a bug on this site</a>
           </li>
         </ul>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,6 +1167,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@canonical/cookie-policy@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.2.tgz#5a6a3d5f02c2fc139e38749e25e14254d4b3cdd8"
+  integrity sha512-xe25hHA9jrfgWTs+pVjO4UL/INnM1Pp0ukYgolMYTc+kwSguAmnXXDN3vhoSOToS6DPU5E6yh7U/wQqXVqos7g==
+
 "@canonical/global-nav@2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.3.tgz#9d552bad1968537c4b952747b27d5d3db21cf327"


### PR DESCRIPTION
## Done

- Add the new cookie module to the site

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the new cookie popup and try the settings
- Test the "Manage your tracker settings" link from the footer


## Issue / Card

Fixes #333 

