### PR TITLE
Fix 341

### DIFF
--- a/templates/partial/_get-started-linux.html
+++ b/templates/partial/_get-started-linux.html
@@ -76,7 +76,7 @@
         Join the community
       </h3>
       <p>
-        <a href="https://discuss.kubernetes.io/tags/microk8s">Connect with our community and see what others are doing with MicroK8s&nbsp;&rsaquo;</a>
+        <a href="https://discuss.kubernetes.io/c/general-discussions/microk8s/26">Connect with our community and see what others are doing with MicroK8s&nbsp;&rsaquo;</a>
       </p>
     </div>
 

--- a/templates/partial/_get-started-macos.html
+++ b/templates/partial/_get-started-macos.html
@@ -85,7 +85,7 @@
         Join the community
       </h3>
       <p>
-        <a href="https://discuss.kubernetes.io/tags/microk8s">Connect with our community and see what others are doing with MicroK8s&nbsp;&rsaquo;</a>
+        <a href="https://discuss.kubernetes.io/c/general-discussions/microk8s/26">Connect with our community and see what others are doing with MicroK8s&nbsp;&rsaquo;</a>
       </p>
     </div>
   </li>


### PR DESCRIPTION
## Done

Fix broken community links on linux and MacOS pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #341 

## Screenshots

[if relevant, include a screenshot]
