### PR TITLE
Set the title of the docs pages

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -2,7 +2,7 @@
 
 {% block page_class %}docs{% endblock %}
 {% block content_class %}l-docs-wrapper{% endblock %}
-{% block page_title %}| {{ document.title }} {% endblock %}
+{% block title %}MicroK8s - {{ document.title }} {% endblock %}
 
 {% block content %}
 <div class="p-strip is-shallow">


### PR DESCRIPTION
## Done
Fix the template variable used for page title

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/docs
- Click through the pages and check the page title reflects the content

## Issue / Card
Fixes https://github.com/canonical-web-and-design/microk8s.io/issues/352
