### PR TITLE
Added ^~ for nginx proxy locations

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -20,7 +20,7 @@ production:
     }
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
   nginxServerSnippet: |
-    location /install/ {
+    location ^~ /install/ {
       rewrite ^/install/(.*).exe /ubuntu/microk8s/releases/download/installer-$1/microk8s-installer.exe break;
       proxy_pass https://github.com/;
     }


### PR DESCRIPTION
This PR is similar to https://github.com/canonical-web-and-design/ubuntu.com/pull/8907

After updating the Konf snap with https://github.com/canonical-web-and-design/konf/pull/5 , we need to use `^~` for the location blocks on Nginx

## Done

- Added `^~` for Nginx proxy locations

## QA

- Deploy the current configuration to microk8s
- Modify your `/etc/hosts/` file
- Try to download microk8s from the website, it should work.
