### PR TITLE
Update redirects.yaml

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,2 +1,2 @@
 /install.exe: /install/v2.0.1.exe
-/microk8s-installer.exe: "https://github.com/ubuntu/microk8s/releases/download/installer-v2.0.2/microk8s-installer.exe"
+/microk8s-installer.exe: "https://github.com/ubuntu/microk8s/releases/download/installer-v2.1.0/microk8s-installer.exe"


### PR DESCRIPTION
Bump to version v2.1.0.  I believe we can also remove ./install.exe redirect.

## Done

*  To reflect new release of installer.