### PR TITLE
Hide install instructions on page load

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -208,3 +208,7 @@
     color: $color-x-light;
   }
 }
+
+.no-js .js-tab__content {
+  display: block !important;
+}

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -77,7 +77,8 @@
   <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}" />
 </head>
 
-<body>
+<body class="no-js">
+  <script>document.querySelector('body').classList.remove('no-js')</script>
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T5SMPTS" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,13 +46,13 @@
    </div>
 
    <div class="row">
-     <div class="col-8 js-tab__content" id="tab-one__content" role="tabpanel" aria-labelledby="tab-one">
+     <div class="col-8 js-tab__content u-hide" id="tab-one__content" role="tabpanel" aria-labelledby="tab-one" >
        {% include "/partial/_get-started-linux.html" %}
      </div>
-     <div class="col-8 js-tab__content" id="tab-two__content" role="tabpanel" aria-labelledby="tab-two">
+     <div class="col-8 js-tab__content u-hide" id="tab-two__content" role="tabpanel" aria-labelledby="tab-two">
        {% include "/partial/_get-started-windows.html" %}
      </div>
-     <div class="col-8 js-tab__content" id="tab-three__content" role="tabpanel" aria-labelledby="tab-three">
+     <div class="col-8 js-tab__content u-hide" id="tab-three__content" role="tabpanel" aria-labelledby="tab-three">
        {% include "/partial/_get-started-macos.html" %}
      </div>
    </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,22 +46,17 @@
    </div>
 
    <div class="row">
-     <div class="col-8 js-tab__content" id="tab-one__content" role="tabpanel" aria-labelledby="tab-one">
+     <div class="col-8 js-tab__content u-hide" id="tab-one__content" role="tabpanel" aria-labelledby="tab-one">
        {% include "/partial/_get-started-linux.html" %}
      </div>
-     <div class="col-8 js-tab__content" id="tab-two__content" role="tabpanel" aria-labelledby="tab-two">
+     <div class="col-8 js-tab__content u-hide" id="tab-two__content" role="tabpanel" aria-labelledby="tab-two">
        {% include "/partial/_get-started-windows.html" %}
      </div>
-     <div class="col-8 js-tab__content" id="tab-three__content" role="tabpanel" aria-labelledby="tab-three">
+     <div class="col-8 js-tab__content u-hide" id="tab-three__content" role="tabpanel" aria-labelledby="tab-three">
        {% include "/partial/_get-started-macos.html" %}
      </div>
    </div>
  </section>
-
- <script>
-   const tabsContent = document.querySelectorAll(".js-tab__content");
-   tabsContent.forEach(tabContent => tabContent.classList.add("u-hide"));
- </script>
 
  <section class="p-strip--light is-deep">
    <div class="row u-equal-height">

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,17 +46,22 @@
    </div>
 
    <div class="row">
-     <div class="col-8 js-tab__content u-hide" id="tab-one__content" role="tabpanel" aria-labelledby="tab-one" >
+     <div class="col-8 js-tab__content" id="tab-one__content" role="tabpanel" aria-labelledby="tab-one">
        {% include "/partial/_get-started-linux.html" %}
      </div>
-     <div class="col-8 js-tab__content u-hide" id="tab-two__content" role="tabpanel" aria-labelledby="tab-two">
+     <div class="col-8 js-tab__content" id="tab-two__content" role="tabpanel" aria-labelledby="tab-two">
        {% include "/partial/_get-started-windows.html" %}
      </div>
-     <div class="col-8 js-tab__content u-hide" id="tab-three__content" role="tabpanel" aria-labelledby="tab-three">
+     <div class="col-8 js-tab__content" id="tab-three__content" role="tabpanel" aria-labelledby="tab-three">
        {% include "/partial/_get-started-macos.html" %}
      </div>
    </div>
  </section>
+
+ <script>
+   const tabsContent = document.querySelectorAll(".js-tab__content");
+   tabsContent.forEach(tabContent => tabContent.classList.add("u-hide"));
+ </script>
 
  <section class="p-strip--light is-deep">
    <div class="row u-equal-height">
@@ -181,7 +186,7 @@
        <p>MicroK8s will apply security updates automatically by default, defer them if you want. Upgrade to a newer version of Kubernetes with a single command. It’s really that easy.</p>
      </div>
      <div class="col-5 u-hide--small u-align--center u-vertically-center">
-       <img src="https://assets.ubuntu.com/v1/dc735dc5-single-line-install.svg" alt="" style="width: 350px; height: 200px;" />
+       <img src="https://assets.ubuntu.com/v1/dc735dc5-single-line-install.svg" alt="" style="height: 200px; width: 350px;" />
      </div>
    </div>
  </section>
@@ -189,7 +194,7 @@
  <section class="p-strip--light is-deep">
    <div class="row u-equal-height">
      <div class="col-5 u-align--center u-vertically-center">
-       <img class="u-hide--small" src="https://assets.ubuntu.com/v1/3ed91139-MicroK8s-%231+for+Containers.svg" alt="" style="width: 267px; height: 200px;" loading="auto">
+       <img class="u-hide--small" src="https://assets.ubuntu.com/v1/3ed91139-MicroK8s-%231+for+Containers.svg" alt="" style="height: 200px;width: 267px;" loading="auto">
      </div>
      <div class="col-7">
        <h2>Fully containerised Kubernetes</h2>
@@ -208,7 +213,7 @@
        <p>MicroK8s defaults to the most widely used Kubernetes options, so it ‘just works’ with no config necessary. Networking, storage and standard services are all provided out of the box with best of breed defaults.</p>
      </div>
      <div class="col-5 u-align--center u-vertically-center u-hide--small">
-       <img src="https://assets.ubuntu.com/v1/cbe37336-MicroK8s-Apps.svg" alt="" width="347" height="200" style="width: 347px; height: 200px;" loading="auto">
+       <img src="https://assets.ubuntu.com/v1/cbe37336-MicroK8s-Apps.svg" alt="" width="347" height="200" style="height: 200px; width: 347px;" loading="auto">
      </div>
    </div>
  </section>
@@ -216,7 +221,7 @@
  <section class="p-strip--light is-deep">
    <div class="row u-equal-height">
      <div class="col-5 u-hide--small u-align--center u-vertically-center">
-       <img src="https://assets.ubuntu.com/v1/9afbad2b-Networking.svg" alt="" style="width: 290px; height: 200px;" loading="auto">
+       <img src="https://assets.ubuntu.com/v1/9afbad2b-Networking.svg" alt="" style="height: 200px; width: 290px;" loading="auto">
      </div>
      <div class="col-7">
        <h2>GPU acceleration</h2>
@@ -244,7 +249,7 @@
  <section class="p-strip--light">
    <div class="row u-equal-height">
      <div class="col-6 u-hide--small u-align--center u-vertically-center">
-       <img src="https://assets.ubuntu.com/v1/c711b814-reliable_updates.svg" alt="" style="width: 350px; height: 200px;" loading="auto">
+       <img src="https://assets.ubuntu.com/v1/c711b814-reliable_updates.svg" alt="" style="height: 200px; width: 350px;" loading="auto">
      </div>
      <div class="col-6">
        <h2>Automatic security updates</h2>
@@ -263,7 +268,7 @@
        <p>So your CI/CD machine spins up a clean VM for each test run? Just install MicroK8s at the top of your script for a crisp, clean K8s to run your tests.</p>
      </div>
      <div class="col-6  u-equal-height u-hide--small u-align--center u-vertically-center">
-       <img src="https://assets.ubuntu.com/v1/dec3872d-MicroK8s-Managed+securely.svg" alt="" style="width:339px; height:200px;" />
+       <img src="https://assets.ubuntu.com/v1/dec3872d-MicroK8s-Managed+securely.svg" alt="" style="height:200px; width:339px;" />
      </div>
    </div>
  </section>


### PR DESCRIPTION
## Done

- Fix bug install instructions visible for a second on page load

## QA

- View page at: https://microk8s-io-379.demos.haus
- Comapre to https://microk8s.io/ where on refresh install instructions are visible for a second.
- Check toggling JS on and off, instructions should be visible with JS disabled and not visible until selected when JS is endabled


## Issue / Card

Fixes #377 

