### PR TITLE
update docs link-checker

### DIFF
--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -17,7 +17,7 @@ jobs:
         run: sudo pip install LinkChecker
 
       - name: Run linkchecker
-        run: linkchecker --threads 2 --ignore-url "https://assets.ubuntu.com$" --check-extern --no-warnings https://microk8s.io/docs
+        run: linkchecker --threads 2 --ignore-url "https://assets.ubuntu.com$" --ignore-url "https*://127.0.0.1.*" --ignore-url ".*.xip.io/.*" --check-extern --no-warnings https://microk8s.io/docs
 
       - name: Send message on failure
         if: failure()


### PR DESCRIPTION
## Done
some suggested filters for the linkchecker

127.0.0.1 addresses are obviously always referring to the user localhost and should be skipped (this should probably be on all the link checkers)
*.xip.io addresses are a special domain used by MicroK8s authentication

Feel free to rewrite the regex to improve it
