### PR TITLE
linkchecker update

### DIFF
--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -17,7 +17,8 @@ jobs:
         run: sudo pip install LinkChecker
 
       - name: Run linkchecker
-        run: linkchecker --threads 2 --ignore-url "https://assets.ubuntu.com$" --ignore-url "https*://127.0.0.1.*" --ignore-url ".*.xip.io/.*" --check-extern --no-warnings https://microk8s.io/docs
+        run: linkchecker --threads 2 --ignore-url "https://assets.ubuntu.com$" --ignore-url "https*://127.0.0.1.*" --ignore-url ".*.xip.io.*" --ignore-url ".*.nip.io.*" --check-extern --no-warnings https://microk8s.io/docs
+
 
       - name: Send message on failure
         if: failure()

--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -17,7 +17,7 @@ jobs:
         run: sudo pip install LinkChecker
 
       - name: Run linkchecker
-        run: linkchecker --threads 2 --ignore-url "https://assets.ubuntu.com$" --ignore-url "https*://127.0.0.1.*" --ignore-url ".*.xip.io.*" --ignore-url ".*.nip.io.*" --check-extern --no-warnings https://microk8s.io/docs
+        run: linkchecker --threads 2 --ignore-url "https://assets.ubuntu.com$" --ignore-url "https*://127.0.0.1.*" --ignore-url ".*.nip.io.*" --check-extern --no-warnings https://microk8s.io/docs
 
 
       - name: Send message on failure


### PR DESCRIPTION


## Done

change linkchecker arguments to also filter .nip.io addresses (used for dns internally in microK8s)

The only remaining errors showing on this are the result of mistaken redirects ( should be fixed by [this PR](https://github.com/canonical-web-and-design/canonicalwebteam.discourse/pull/102))


