### PR TITLE
Added cta button on landing page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,7 @@
         <br />
         for devs, cloud, clusters, workstations, Edge and IoT.
        </p>
+       <p><a class="p-button--positive" href="/contact-us">Get in touch</a></p>
      </div>
      <div class="col-5 u-align--center u-hide--small u-embedded-media">
        <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/v9KI2BAF5QU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/templates/index.html
+++ b/templates/index.html
@@ -296,7 +296,7 @@
        <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" alt="" width="250" height="178" loading="lazy">
      </div>
      <div class="col-7">
-       <h2>Need help?</h2>
+       <h2>Need help with Kubernetes?</h2>
        <p>Get in touch with one of our engineers.</p>
        <p><a href="/contact-us" class="p-button--positive">Contact us</a></p>
      </div>


### PR DESCRIPTION
## Done

Added CTA button to landing site and updated copy on end of page 

## QA

- View page at: https://microk8s-io-439.demos.haus
- Copydoc: https://docs.google.com/document/d/1ObWmhRc4GCIhrBi8gT7yIIs0J_dn_8ravfLtcwhr3uQ/edit#heading=h.pt6iw0mepowo
- Button should lead to https://microk8s.io/contact-us

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4404

## Screenshots

<img width="1391" alt="Screenshot 2021-09-07 at 14 25 13" src="https://user-images.githubusercontent.com/17607612/132344114-37bc0fb2-0791-4e29-bde2-aa0bae71f58b.png">

[if relevant, include a screenshot]
