### PR TITLE
Add dynamic copy doc links to the head of each page

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -5,7 +5,7 @@
 {% block meta_description %}Sorry, we can't find the page you're looking for.{% endblock %}
 
 {% block content %}
-<div class="p-strip is-deep u-extra-space">
+<div class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-6">
       <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Error owl" width="400" height="400" />

--- a/templates/500.html
+++ b/templates/500.html
@@ -5,7 +5,7 @@
 {% block meta_description %}Something&rsquo;s gone wrong.{% endblock %}
 
 {% block content %}
-<div class="p-strip is-deep u-extra-space">
+<div class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-6">
       <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Error owl" width="400" height="400" />

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -14,7 +14,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <meta name="copydoc" content="https://docs.google.com/document/d/1ObWmhRc4GCIhrBi8gT7yIIs0J_dn_8ravfLtcwhr3uQ/edit">
+
+  <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/1p6lHFpMFXFeSmVUx3Hyw-zlySn8MZHpP{% endblock %}">
 
   <title>
     {% block title %}MicroK8s - Zero-ops Kubernetes for developers, edge and IoT{% endblock %}
@@ -73,6 +74,8 @@
   <meta name="twitter:description" content="{{ self.meta_description() }}">
   <meta property="og:description" content="{{ self.meta_description() }}">
   {% endif %}
+
+  {% block head_extra %}{% endblock %}
 
   <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}" />
 </head>

--- a/templates/features/high-availability.html
+++ b/templates/features/high-availability.html
@@ -44,7 +44,7 @@
           HA MicroK8s provides API services on all nodes. This means that any node in the cluster can be a target for kubectl. Administrators can perform tasks on any node. Three of the nodes are automatically selected to provide the datastore for the Kubernetes control plane, based on their capacity and utilisation. In the event of a datastore node failure, a different node is promoted to participate in the datastore consensus.
         </p>
         <div class="u-align--center u-embedded-media">
-	       <iframe title="MicroK8s HA setup demonstration video" class="u-embedded-media__element" src="https://www.youtube.com/embed/pRVCxNSf-Oo" allowfullscreen=""></iframe>  
+	       <iframe title="MicroK8s HA setup demonstration video" class="u-embedded-media__element" src="https://www.youtube.com/embed/pRVCxNSf-Oo" allowfullscreen=""></iframe>
         </div>
         <br />
         <h2>Autonomous HA Kubernetes</h2>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,7 @@
 {% extends 'base_layout.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1ObWmhRc4GCIhrBi8gT7yIIs0J_dn_8ravfLtcwhr3uQ/edit{% endblock %}
+
 {% block content %}
 <main id="main-content">
 

--- a/templates/thank-you.html
+++ b/templates/thank-you.html
@@ -1,6 +1,6 @@
 {% extends 'base_layout.html' %}
 {% block title %}MicroK8s - Contact-us{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1KkLHMrGipY4zgIXreujpyJlLvYUs-iAlP-FtpYrZmWA/edit {% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1zAmRxMVFQhUPv9jBjVHJPnWfJMjiB78dQfY__h4pE7o/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <main id="main-content">

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -2,6 +2,8 @@
 
 {% block title %}MicroK8s tutorials{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1Lpo7Od9VA1aHYmr9UVp02vCGOP5Zxmzx4zZE9YJwlQg/edit{% endblock %}
+
 {% block content %}
 
 <section class="p-strip">


### PR DESCRIPTION
## Done
Add dynamic copy doc links to the head of each page

## QA
- Go to pages in the demo and check the correct copy doc is linked
- Check the copy docs links against the pages here: https://drive.google.com/drive/folders/1p6lHFpMFXFeSmVUx3Hyw-zlySn8MZHpP

## Issue / Card
Fixes https://github.com/canonical-web-and-design/microk8s.io/issues/455
