### PR TITLE
Add new microk8s tutorial

### DIFF
--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -14,6 +14,18 @@
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <div class="p-card__content">
+        <h3 class="p-heading--four"><a class="p-link--external" href="https://ubuntu.com/tutorials/installing-microk8s-on-apple-m1-silicone#1-installation">Installing MicroK8s on Apple M1 silicon</a></h3>
+        <p>
+          Install Kubernetes on Apple M1 with Microk8s and Multipass.
+        </p>
+      </div>
+      <p>
+        Difficulty: <span class="p-tutorials-meter p-tutorials-meter--1">1 out of 5</span>
+      </p>
+    </div>
+
+    <div class="col-4 p-card">
+      <div class="p-card__content">
         <h3 class="p-heading--four"><a class="p-link--external" href="https://ubuntu.com/tutorials/install-microk8s-on-windows#1-overview">Install MicroK8s on Windows</a></h3>
         <p>
           Get a local Kubernetes on Windows with MicroK8s and Multipass.
@@ -46,10 +58,7 @@
         Difficulty: <span class="p-tutorials-meter p-tutorials-meter--1">1 out of 5</span>
       </p>
     </div>
-  </div>
 
-
-  <div class="row u-equal-height">
     <div class="col-4 p-card">
       <div class="p-card__content">
         <h3 class="p-heading--four"><a class="p-link--external" href="https://ubuntu.com/tutorials/getting-started-with-kubernetes-ha#1-overview">How to build a highly available Kubernetes cluster with MicroK8s</a></h3>

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -14,7 +14,7 @@
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <div class="p-card__content">
-        <h3 class="p-heading--four"><a class="p-link--external" href="https://ubuntu.com/tutorials/installing-microk8s-on-apple-m1-silicone#1-installation">Installing MicroK8s on Apple M1 silicon</a></h3>
+        <h3 class="p-heading--four"><a class="p-link--external" href="https://ubuntu.com/tutorials/installing-microk8s-on-apple-m1-silicon#1-installation">Installing MicroK8s on Apple M1 silicon</a></h3>
         <p>
           Install Kubernetes on Apple M1 with Microk8s and Multipass.
         </p>


### PR DESCRIPTION
## Done

- Added "Installing MicroK8s on Apple M1 silicon" tutorial to /tutorials
- Created related issue to fetch tutorials dynamically: https://github.com/canonical-web-and-design/microk8s.io/issues/460

## QA
- View the demo in your web browser at: https://microk8s-io-459.demos.haus7/tutorials
- See that "Installing MicroK8s on Apple M1 silicon" is the first tutorial there, and that it links to the right tutorial on ubuntu.com
