### PR TITLE
Fix "ARMhf" typo on /compare

### DIFF
--- a/templates/compare/index.html
+++ b/templates/compare/index.html
@@ -62,7 +62,7 @@
         <tr>
           <td aria-label="Category">Architecture support</td>
           <td aria-label="MicroK8s" class="u-align--center"> x86, ARM64, s390x </td>
-          <td aria-label="K3s" class="u-align--center"> x86, ARM64, ARMh </td>
+          <td aria-label="K3s" class="u-align--center"> x86, ARM64, ARMhf</td>
           <td aria-label="minikube" class="u-align--center"> x86, ARM64, ARMv7, ppc64,  s390x </td>
         </tr>
         <tr>


### PR DESCRIPTION
## Done

- Changed "ARMh" to "ARMhf", as pointed out in the [copy doc](https://docs.google.com/document/d/1wWos3iWMTCqDbxZBDuSVqvY6ZwYux-goCrX0L0E5Weo/edit?disco=AAAAUFcgKWQ)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/compare
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that "ARMhf" appears in the "Architecture support" row of the table, not "ARMh"
