### PR TITLE
Make compare table responsive

### DIFF
--- a/templates/compare/index.html
+++ b/templates/compare/index.html
@@ -25,7 +25,7 @@
 </section>
 <section class="p-strip--light">
   <div class="u-fixed-width">
-    <table class="p-table--mobile-card">
+    <table class="p-table">
       <thead>
         <tr>
           <th>&nbsp;</th>

--- a/templates/compare/index.html
+++ b/templates/compare/index.html
@@ -25,7 +25,7 @@
 </section>
 <section class="p-strip--light">
   <div class="u-fixed-width">
-    <table class="p-table">
+    <table class="p-table--mobile-card">
       <thead>
         <tr>
           <th>&nbsp;</th>
@@ -36,146 +36,146 @@
       </thead>
       <tbody>
         <tr>
-          <td aria-label="Category">CNCF certified</td>
-          <td aria-label="MicroK8s" class="u-align--center">
+          <td data-heading="Category">CNCF certified</td>
+          <td data-heading="MicroK8s" class="u-align--center">
             <i class="p-icon--success">Yes</i>
           </td>
-          <td aria-label="K3s" class="u-align--center">
+          <td data-heading="K3s" class="u-align--center">
             <i class="p-icon--success">Yes</i>
           </td>
-          <td aria-label="minikube" class="u-align--center">
+          <td data-heading="minikube" class="u-align--center">
             <i class="p-icon--success">Yes</i>
           </td>
         </tr>
         <tr>
-          <td aria-label="Category">Vanilla Kubernetes</td>
-          <td aria-label="MicroK8s" class="u-align--center">
+          <td data-heading="Category">Vanilla Kubernetes</td>
+          <td data-heading="MicroK8s" class="u-align--center">
             <i class="p-icon--success">Yes</i>
           </td>
-          <td aria-label="K3s" class="u-align--center">
+          <td data-heading="K3s" class="u-align--center">
             <span aria-label="No">&ndash;</span>
           </td>
-          <td aria-label="minikube" class="u-align--center">
+          <td data-heading="minikube" class="u-align--center">
             <i class="p-icon--success">Yes</i>
           </td>
         </tr>
         <tr>
-          <td aria-label="Category">Architecture support</td>
-          <td aria-label="MicroK8s" class="u-align--center"> x86, ARM64, s390x </td>
-          <td aria-label="K3s" class="u-align--center"> x86, ARM64, ARMhf</td>
-          <td aria-label="minikube" class="u-align--center"> x86, ARM64, ARMv7, ppc64,  s390x </td>
+          <td data-heading="Category">Architecture support</td>
+          <td data-heading="MicroK8s" class="u-align--center"> x86, ARM64, s390x </td>
+          <td data-heading="K3s" class="u-align--center"> x86, ARM64, ARMhf</td>
+          <td data-heading="minikube" class="u-align--center"> x86, ARM64, ARMv7, ppc64,  s390x </td>
         </tr>
         <tr>
-          <td aria-label="Category">Enterprise support</td>
-          <td aria-label="MicroK8s" class="u-align--center">
+          <td data-heading="Category">Enterprise support</td>
+          <td data-heading="MicroK8s" class="u-align--center">
             <i class="p-icon--success">Yes</i>
           </td>
-          <td aria-label="K3s"class="u-align--center" >
+          <td data-heading="K3s"class="u-align--center" >
             <i class="p-icon--success">Yes</i>
           </td>
-          <td aria-label="minikube" class="u-align--center">
-            <span aria-label="No">&ndash;</span>
-          </td>
-        </tr>
-        <tr>
-          <td aria-label="Category">Single-node support</td>
-          <td aria-label="MicroK8s" class="u-align--center">
-            <i class="p-icon--success">Yes</i>
-          </td>
-          <td aria-label="K3s"class="u-align--center" >
-            <i class="p-icon--success">Yes</i>
-          </td>
-          <td aria-label="minikube" class="u-align--center">
-            <i class="p-icon--success">Yes</i>
-          </td>
-        </tr>
-        <tr>
-          <td aria-label="Category">Multi-node cluster support</td>
-          <td aria-label="MicroK8s" class="u-align--center">
-            <i class="p-icon--success">Yes</i>
-          </td>
-          <td aria-label="K3s" class="u-align--center">
-            <i class="p-icon--success">Yes</i>
-          </td>
-          <td aria-label="minikube" class="u-align--center">
+          <td data-heading="minikube" class="u-align--center">
             <span aria-label="No">&ndash;</span>
           </td>
         </tr>
         <tr>
-          <td aria-label="Category">Automatic high availability</td>
-          <td aria-label="MicroK8s" class="u-align--center">
+          <td data-heading="Category">Single-node support</td>
+          <td data-heading="MicroK8s" class="u-align--center">
             <i class="p-icon--success">Yes</i>
           </td>
-          <td aria-label="K3s" class="u-align--center">
-            <span aria-label="No">&ndash;</span>
-          </td>
-          <td aria-label="minikube" class="u-align--center">
-            <span aria-label="No">&ndash;</span>
-          </td>
-        </tr>
-        <tr>
-          <td aria-label="Category">Automatic updates</td>
-          <td aria-label="MicroK8s" class="u-align--center">
+          <td data-heading="K3s"class="u-align--center" >
             <i class="p-icon--success">Yes</i>
           </td>
-          <td aria-label="K3s" class="u-align--center">
-            <span aria-label="No">&ndash;</span>
-          </td>
-          <td aria-label="minikube" class="u-align--center">
-            <span aria-label="No">&ndash;</span>
-          </td>
-        </tr>
-        <tr>
-          <td aria-label="Category">Memory requirements</td>
-          <td aria-label="MicroK8s" class="u-align--center"> 540 MB </td>
-          <td aria-label="K3s" class="u-align--center"> 512 MB </td>
-          <td aria-label="minikube" class="u-align--center"> 2 GB </td>
-        </tr>
-        <tr>
-          <td aria-label="Category">Add-on functionality</td>
-          <td aria-label="MicroK8s" class="u-align--center">
-            <i class="p-icon--success">Yes</i>
-          </td>
-          <td aria-label="K3s" class="u-align--center">
-            <span aria-label="No">&ndash;</span>
-          </td>
-          <td aria-label="minikube" class="u-align--center">
+          <td data-heading="minikube" class="u-align--center">
             <i class="p-icon--success">Yes</i>
           </td>
         </tr>
         <tr>
-          <td aria-label="Category">Container runtime</td>
-          <td aria-label="MicroK8s" class="u-align--center">
+          <td data-heading="Category">Multi-node cluster support</td>
+          <td data-heading="MicroK8s" class="u-align--center">
+            <i class="p-icon--success">Yes</i>
+          </td>
+          <td data-heading="K3s" class="u-align--center">
+            <i class="p-icon--success">Yes</i>
+          </td>
+          <td data-heading="minikube" class="u-align--center">
+            <span aria-label="No">&ndash;</span>
+          </td>
+        </tr>
+        <tr>
+          <td data-heading="Category">Automatic high availability</td>
+          <td data-heading="MicroK8s" class="u-align--center">
+            <i class="p-icon--success">Yes</i>
+          </td>
+          <td data-heading="K3s" class="u-align--center">
+            <span aria-label="No">&ndash;</span>
+          </td>
+          <td data-heading="minikube" class="u-align--center">
+            <span aria-label="No">&ndash;</span>
+          </td>
+        </tr>
+        <tr>
+          <td data-heading="Category">Automatic updates</td>
+          <td data-heading="MicroK8s" class="u-align--center">
+            <i class="p-icon--success">Yes</i>
+          </td>
+          <td data-heading="K3s" class="u-align--center">
+            <span aria-label="No">&ndash;</span>
+          </td>
+          <td data-heading="minikube" class="u-align--center">
+            <span aria-label="No">&ndash;</span>
+          </td>
+        </tr>
+        <tr>
+          <td data-heading="Category">Memory requirements</td>
+          <td data-heading="MicroK8s" class="u-align--center"> 540 MB </td>
+          <td data-heading="K3s" class="u-align--center"> 512 MB </td>
+          <td data-heading="minikube" class="u-align--center"> 2 GB </td>
+        </tr>
+        <tr>
+          <td data-heading="Category">Add-on functionality</td>
+          <td data-heading="MicroK8s" class="u-align--center">
+            <i class="p-icon--success">Yes</i>
+          </td>
+          <td data-heading="K3s" class="u-align--center">
+            <span aria-label="No">&ndash;</span>
+          </td>
+          <td data-heading="minikube" class="u-align--center">
+            <i class="p-icon--success">Yes</i>
+          </td>
+        </tr>
+        <tr>
+          <td data-heading="Category">Container runtime</td>
+          <td data-heading="MicroK8s" class="u-align--center">
             containerd, kata
           </td>
-          <td aria-label="K3s" class="u-align--center">
+          <td data-heading="K3s" class="u-align--center">
             CRI-O
           </td>
-          <td aria-label="minikube" class="u-align--center">
+          <td data-heading="minikube" class="u-align--center">
             Docker, containerd, CRI-O
           </td>
         </tr>
         <tr>
-          <td aria-label="Category">Networking</td>
-          <td aria-label="MicroK8s" class="u-align--center">Calico, Cilium, CoreDNS, Traefik, NGINX, Ambassador, Multus, MetalLB</td>
-          <td aria-label="K3s" class="u-align--center">Flannel, CoreDNS, Traefik, Canal, Klipper</td>
-          <td aria-label="minikube" class="u-align--center">Calico, Cilium, Flannel, ingress, DNS, Kindnet</td>
+          <td data-heading="Category">Networking</td>
+          <td data-heading="MicroK8s" class="u-align--center">Calico, Cilium, CoreDNS, Traefik, NGINX, Ambassador, Multus, MetalLB</td>
+          <td data-heading="K3s" class="u-align--center">Flannel, CoreDNS, Traefik, Canal, Klipper</td>
+          <td data-heading="minikube" class="u-align--center">Calico, Cilium, Flannel, ingress, DNS, Kindnet</td>
         </tr>
         <tr>
-          <td aria-label="Category">Storage</td>
-          <td aria-label="MicroK8s" class="u-align--center">Hostpath storage, OpenEBS, Ceph</td>
-          <td aria-label="K3s" class="u-align--center">Hostpath storage, Longhorn</td>
-          <td aria-label="minikube" class="u-align--center">Hostpath storage</td>
+          <td data-heading="Category">Storage</td>
+          <td data-heading="MicroK8s" class="u-align--center">Hostpath storage, OpenEBS, Ceph</td>
+          <td data-heading="K3s" class="u-align--center">Hostpath storage, Longhorn</td>
+          <td data-heading="minikube" class="u-align--center">Hostpath storage</td>
         </tr>
         <tr>
-          <td aria-label="Category">GPU acceleration</td>
-          <td aria-label="MicroK8s" class="u-align--center">
+          <td data-heading="Category">GPU acceleration</td>
+          <td data-heading="MicroK8s" class="u-align--center">
             <i class="p-icon--success">Yes</i>
           </td>
-          <td aria-label="K3s" class="u-align--center">
+          <td data-heading="K3s" class="u-align--center">
             <span aria-label="No">&ndash;</span>
           </td>
-          <td aria-label="minikube" class="u-align--center">
+          <td data-heading="minikube" class="u-align--center">
             <i class="p-icon--success">Yes</i>
           </td>
         </tr>


### PR DESCRIPTION
## Done

Removes the `mobile-card` class from the 'compare' table. The table is still readable without a mobile class.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://microk8s-io-509.demos.haus/compare
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the table is readable on different screen sizes.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/microk8s.io/issues/506
