### PR TITLE
Copy update on /tutorials

### DIFF
--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -82,7 +82,7 @@
     </div>
     <div class="col-4 p-card">
       <div class="p-card__content">
-        <h3 class="p-heading--four"><a class="p-link--external" href="https://ubuntu.com/tutorials/installing-microk8s-on-apple-m1-silicon#1-installation">Installing MicroK8s on Apple M1 silicon</a></h3>
+        <h3 class="p-heading--4"><a class="p-link--external" href="https://ubuntu.com/tutorials/installing-microk8s-on-apple-m1-silicon#1-installation">Installing MicroK8s on Apple M1 silicon</a></h3>
         <p>
           Install Kubernetes on Apple M1 with Microk8s and Multipass.
         </p>
@@ -93,7 +93,7 @@
     </div>
     <div class="col-4 p-card">
       <div class="p-card__content">
-        <h3 class="p-heading--four"><a class="p-link--external" href="https://ubuntu.com/tutorials/getting-started-with-microk8s-on-ubuntu-core">Getting started with MicroK8s on Ubuntu Core</a></h3>
+        <h3 class="p-heading--4"><a class="p-link--external" href="https://ubuntu.com/tutorials/getting-started-with-microk8s-on-ubuntu-core">Getting started with MicroK8s on Ubuntu Core</a></h3>
         <p>
          Get an embedded Kubernetes deployment on your IoT devices with MicroK8s and Ubuntu Core.
         </p>
@@ -104,13 +104,24 @@
     </div>
     <div class="col-4 p-card">
       <div class="p-card__content">
-        <h3 class="p-heading--four"><a class="p-link--external" href="https://ubuntu.com/tutorials/self-healing-kubernetes-deployments-with-microk8s-and-portainer">Self-healing Kubernetes deployments with Microk8s and Portainer</a></h3>
+        <h3 class="p-heading--4"><a class="p-link--external" href="https://ubuntu.com/tutorials/self-healing-kubernetes-deployments-with-microk8s-and-portainer">Self-healing Kubernetes deployments with Microk8s and Portainer</a></h3>
         <p>
           Install Ubuntu and Microk8s on all of the Raspberry Pi nodes and enable Portainer.
         </p>
       </div>
       <p>
         Difficulty: <span class="p-tutorials-meter p-tutorials-meter--1">1 out of 5</span>
+      </p>
+    </div>
+    <div class="col-4 p-card">
+      <div class="p-card__content">
+        <h3 class="p-heading--4"><a class="p-link--external" href="https://ubuntu.com/tutorials/accelerated-ml-experiments-on-microk8s-with-inaccel-fpga-operator-and-kubeflow-katib">Accelerated ML experiments on MicroK8s with InAccel FPGA Operator and Kubeflow Katib</a></h3>
+        <p>
+          In this tutorial, you will learn how to integrate FPGAs with Kubernetes and accelerate the hyperparameter tuning of your ML models.
+        </p>
+      </div>
+      <p>
+        Difficulty: <span class="p-tutorials-meter p-tutorials-meter--2">2 out of 5</span>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Add one tutorial on the `/tutorials` page
- Update `p-heading--four` to `p-heading--4`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare page against [copy doc](https://docs.google.com/document/d/1Lpo7Od9VA1aHYmr9UVp02vCGOP5Zxmzx4zZE9YJwlQg/edit)
- Demo at https://microk8s-io-523.demos.haus/tutorials


## Issue / Card

Fixes [#5032](https://github.com/canonical-web-and-design/web-squad/issues/5032)

## Screenshots

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/57550290/162247211-dd159f74-f584-4992-9962-faf4da0d6756.png">
