### PR TITLE
Fix typo on index

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,7 @@
    </div>
    <div class="row u-equal-height">
      <div class="col-4">
-       <h4>For Develoeprs</h4>
+       <h4>For Developers</h4>
        <p>MicroK8s is the easiest and fastest way to get Kubernetes up and running. Experiment with the latest upstream features and toggle services on and off. Seamlessly move your work from dev to production.</p>
      </div>
      <div class="col-4">


### PR DESCRIPTION
## Done

- Fixed typo: "develoeprs" to "developers"

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- See that the change has been made


## Issue / Card

Fixes https://github.com/canonical-web-and-design/microk8s.io/issues/525
