### PR TITLE
Expandable side navigation

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -4,18 +4,26 @@
 
 {% block content %}
 
-{% macro create_navigation(nav_items) %}
-  <ul>
+{% macro create_navigation(nav_items, expandable=False) %}
+  <ul class="p-side-navigation__list">
     {% for element in nav_items %}
-    <li>
+    <li class="p-side-navigation__item">
       {% if element.navlink_href %}
-        <a href="{{ element.navlink_href }}" {% if request.path == element.navlink_href %}aria-current="page"{% endif %}>{{ element.navlink_text }}</a>
+        <a class="p-side-navigation__link" href="{{ element.navlink_href }}" 
+          {% if element.is_active %}aria-current="page"{% endif %}>
+          {{ element.navlink_text }}</a>
       {% else %}
-        <strong>{{ element.navlink_text }}</strong>
+        <span class="p-side-navigation__text">{{ element.navlink_text }}</span>
       {% endif %}
 
-      {% if element.children %}
-        {{ create_navigation(element.children) }}
+      {% if expandable %}
+        {% if element.children and (element.is_active or element.has_active_child) %}
+          {{ create_navigation(element.children, True) }}
+        {% endif %}
+      {% else %}
+        {% if element.children %}
+          {{ create_navigation(element.children, False) }}
+        {% endif %}
       {% endif %}
     </li>
     {% endfor %}
@@ -34,7 +42,7 @@
 <div class="p-strip is-shallow">
   <div class="row">
     <aside class="col-3">
-      <div class="p-side-navigation--raw-html" id="drawer">
+      <div class="p-side-navigation" id="drawer">
         <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </a>
@@ -46,13 +54,21 @@
             </a>
           </div>
           {% for nav_group in navigation.nav_items %}
-            {% if not nav_group.hidden %}
+            {% if nav_group.navlink_text %}
               {% if nav_group.navlink_href %}
-                <h3><a class="p-link--soft" href="{{ nav_group.navlink_href }}" {% if request.path == nav_group.navlink_href %}aria-current="page"{% endif %}>{{ nav_group.navlink_text }}</a></h3>
-              {% elif nav_group.navlink_text %}
-                <h3>{{ nav_group.navlink_text }}</h3>
+                <h3 class="p-side-navigation__heading--linked">
+                  <a class="p-side-navigation__link" href="{{ nav_group.navlink_href }}" {% if nav_group.is_active %}aria-current="page"{% endif %}>
+                    {{ nav_group.navlink_text }}
+                  </a>
+                </h3>
+              {% else %}
+                <h3 class="p-side-navigation__heading">{{ nav_group.navlink_text }}</h3>
               {% endif %}
-              {{ create_navigation(nav_group.children) }}
+              {#
+                Use `create_navigation(nav_group.children)` for a default, fully expanded navigation.
+                Use `create_navigation(nav_group.children, expandable=True)` for the nested nav levels to expand only when parent page is active.
+              #}
+              {{ create_navigation(nav_group.children, expandable=True) }} 
             {% endif %}
           {% endfor %}
         </div>
@@ -80,71 +96,4 @@
   </div>
 </div>
 
-<script>
-  var links = [].slice.call(document.querySelectorAll('.p-side-navigation--raw-html li > a'));
-  var currentPath = window.location.pathname;
-
-  links.forEach(function (link) {
-    link.addEventListener('click', function () {
-      links.forEach(function (link) {
-        link.removeAttribute('aria-current');
-      });
-      this.setAttribute('aria-current', 'page');
-      this.blur();
-    });
-
-    if (link.getAttribute('href') === currentPath) {
-      link.setAttribute('aria-current', 'page');
-    }
-  });
-
-  /**
-    Toggles the expanded/collapsed classed on side navigation element.
-    @param {HTMLElement} sideNavigation The side navigation element.
-    @param {Boolean} show Whether to show or hide the drawer.
-  */
-  function toggleDrawer(sideNavigation, show) {
-    if (sideNavigation) {
-      if (show) {
-        sideNavigation.classList.remove('is-collapsed');
-        sideNavigation.classList.add('is-expanded');
-      } else {
-        sideNavigation.classList.remove('is-expanded');
-        sideNavigation.classList.add('is-collapsed');
-      }
-    }
-  }
-
-  /**
-    Attaches event listeners for the side navigation toggles
-    @param {HTMLElement} sideNavigation The side navigation element.
-  */
-  function setupSideNavigation(sideNavigation) {
-    var toggles = [].slice.call(sideNavigation.querySelectorAll('.js-drawer-toggle'));
-
-    toggles.forEach(function (toggle) {
-      toggle.addEventListener('click', function (event) {
-        event.preventDefault();
-        var sideNav = document.getElementById(toggle.getAttribute('aria-controls'));
-
-        if (sideNav) {
-          toggleDrawer(sideNav, !sideNav.classList.contains('is-expanded'));
-        }
-      });
-    });
-  }
-
-  /**
-    Attaches event listeners for all the side navigations in the document.
-    @param {String} sideNavigationSelector The CSS selector matching side navigation elements.
-  */
-  function setupSideNavigations(sideNavigationSelector) {
-    // Setup all side navigations on the page.
-    var sideNavigations = [].slice.call(document.querySelectorAll(sideNavigationSelector));
-
-    sideNavigations.forEach(setupSideNavigation);
-  }
-
-  setupSideNavigations('.p-side-navigation, [class*="p-side-navigation--"]');
-</script>
 {% endblock %}

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -10,7 +10,7 @@
     <li class="p-side-navigation__item">
       {% if element.navlink_href %}
         <a class="p-side-navigation__link" href="{{ element.navlink_href }}" 
-          {% if element.is_active %}aria-current="page"{% endif %}>
+          {% if element.is_active and element.navlink_fragment == "" %}aria-current="page"{% endif %}>
           {{ element.navlink_text }}</a>
       {% else %}
         <span class="p-side-navigation__text">{{ element.navlink_text }}</span>
@@ -57,7 +57,7 @@
             {% if nav_group.navlink_text %}
               {% if nav_group.navlink_href %}
                 <h3 class="p-side-navigation__heading--linked">
-                  <a class="p-side-navigation__link" href="{{ nav_group.navlink_href }}" {% if nav_group.is_active %}aria-current="page"{% endif %}>
+                  <a class="p-side-navigation__link" href="{{ nav_group.navlink_href }}" {% if nav_group.is_active and nav_group.navlink_fragment == "" %}aria-current="page"{% endif %}>
                     {{ nav_group.navlink_text }}
                   </a>
                 </h3>


### PR DESCRIPTION
## Done

- Added expandable side navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://microk8s-io-549.demos.haus/docs
- Click on "Alternative install methods" on the side nav (currently the only nav item with children)
- See that it expands as expected and that the child links also behave as expected 
- Click on any other side nav link and see that "Alternative install methods" collapses 


## Issue / Card

Fixes https://github.com/canonical-web-and-design/microk8s.io/issues/538
