### PR TITLE
get started: Remove 'enable istio' (now in community repos) (fixes #634)

### DIFF
--- a/templates/partial/_get-started-linux.html
+++ b/templates/partial/_get-started-linux.html
@@ -46,7 +46,6 @@
                 <pre class="p-code-snippet__block"><code>microk8s enable dashboard</code></pre>
                 <pre class="p-code-snippet__block"><code>microk8s enable dns</code></pre>
                 <pre class="p-code-snippet__block"><code>microk8s enable registry</code></pre>
-                <pre class="p-code-snippet__block"><code>microk8s enable istio</code></pre>
               </div>
               <p>Try <code>microk8s enable --help</code> for a list of available services and optional features. <code>microk8s disable &lt;name&gt;</code> turns off a service.</p>
             </div>     

--- a/templates/partial/_get-started-macos.html
+++ b/templates/partial/_get-started-macos.html
@@ -52,7 +52,6 @@
                 <pre class="p-code-snippet__block"><code>microk8s enable dashboard</code></pre>
                 <pre class="p-code-snippet__block"><code>microk8s enable dns</code></pre>
                 <pre class="p-code-snippet__block"><code>microk8s enable registry</code></pre>
-                <pre class="p-code-snippet__block"><code>microk8s enable istio</code></pre>
               </div>
               <p>
                 Try <code>microk8s enable --help</code> for a list of available services built in. <code>microk8s disable</code> turns off a service.

--- a/templates/partial/_get-started-windows.html
+++ b/templates/partial/_get-started-windows.html
@@ -75,7 +75,6 @@
                 <pre class="p-code-snippet__block"><code>microk8s enable dashboard</code></pre>
                 <pre class="p-code-snippet__block"><code>microk8s enable dns</code></pre>
                 <pre class="p-code-snippet__block"><code>microk8s enable registry</code></pre>
-                <pre class="p-code-snippet__block"><code>microk8s enable istio</code></pre>
               </div>
               <p>
                 Try <code>microk8s enable --help</code> for a list of available services built in. microk8s disable turns off a service.


### PR DESCRIPTION
## Done

Remove `microk8s enable istio` from the instructions, because it depends on community repositories

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- The `microk8s enable istio` item in step 3. of the getting started guide has been removed for Linux, macOS and Windows

## Issue / Card

Fixes #634
