### PR TITLE
feat: Implement cross-domain cookie sharing

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -17,9 +17,10 @@ env:
       name: google-api
 
   - name: COOKIES_API_KEY
-    secretKeyRef:
-      key: cookies-api-key
-      name: cookies-canonical-com-credentials
+    valueFrom:
+      secretKeyRef:
+        key: cookies-api-key
+        name: cookies-canonical-com-credentials
 
 # Overrides for production
 production:

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -16,11 +16,10 @@ env:
       key: google-custom-search-key
       name: google-api
 
-  - name: COOKIES_API_KEY
-    valueFrom:
-      secretKeyRef:
-        key: cookies-api-key
-        name: cookies-canonical-com-credentials
+  - name: COOKIE_SERVICE_API_KEY
+    secretKeyRef:
+      key: cookies-api-key
+      name: cookies-canonical-com-credentials
 
 # Overrides for production
 production:

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -16,6 +16,11 @@ env:
       key: google-custom-search-key
       name: google-api
 
+  - name: COOKIES_API_KEY
+    secretKeyRef:
+      key: cookies-api-key
+      name: cookies-canonical-com-credentials
+
 # Overrides for production
 production:
   replicas: 5

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test-js": "jest"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "3.6.4",
+    "@canonical/cookie-policy": "3.8.0",
     "@canonical/global-nav": "3.6.4",
     "autoprefixer": "10.4.13",
     "babel-loader": "9.1.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 canonicalwebteam.flask-base==2.5.0
 canonicalwebteam.discourse==5.7.1
 canonicalwebteam.search==2.1.1
+canonicalwebteam.cookie-service==1.0.0
+Flask-Caching==2.1.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,8 +1,10 @@
 # Packages
+from datetime import timedelta
 from canonicalwebteam.flask_base.app import FlaskBase
 from flask import render_template
 import talisker
 import flask
+from flask_caching import Cache
 
 from canonicalwebteam.discourse import (
     Docs,
@@ -10,6 +12,7 @@ from canonicalwebteam.discourse import (
     DiscourseAPI,
 )
 from canonicalwebteam.search import build_search_view
+from canonicalwebteam.cookie_service import CookieConsent
 
 
 # Rename your project below
@@ -23,6 +26,35 @@ app = FlaskBase(
 )
 
 session = talisker.requests.get_session()
+
+# Configuration for shared cookie service
+
+# Configure Flask session
+app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(days=365)
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+app.config["SESSION_COOKIE_HTTPONLY"] = True
+app.config["SESSION_COOKIE_SECURE"] = True
+
+# Initialize Flask-Caching
+app.config["CACHE_TYPE"] = "SimpleCache"
+cache = Cache(app)
+
+
+# Set up cache functions for cookie consent service
+def get_cache(key):
+    return cache.get(key)
+
+
+def set_cache(key, value, timeout):
+    cache.set(key, value, timeout)
+
+
+cookie_service = CookieConsent().init_app(
+    app,
+    get_cache_func=get_cache,
+    set_cache_func=set_cache,
+    start_health_check=True,
+)
 
 discourse = Docs(
     parser=DocParser(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1116,10 +1116,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@3.6.4":
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.4.tgz#895c3770f621b73d88b0d5843c43a32d99e4a462"
-  integrity sha512-kfwamTpAaBhtH5TzlMb8wE814a8lIbONUuSYnS7VPiHDfcdmw4NoBPNpldmNY1j3CAT5vMKOx5kulRTWpEXpag==
+"@canonical/cookie-policy@3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.8.0.tgz#8f20b5d6d0c2e5553bbe05d1513f7f1af7d0836c"
+  integrity sha512-njUYf10gFmuXr47Aj5jayuFbyq08IkBdr/W6qtvHjZvJ8Dt4ru9ehMacWa4mostfQoXVARusIucOARSgnMoArg==
 
 "@canonical/global-nav@3.6.4":
   version "3.6.4"


### PR DESCRIPTION
## Done

- Implements [cookie service flask extension](https://github.com/canonical/canonicalwebteam.cookie-service) for integration with cookies.canonical.com
- Bumps cookie-policy npm package to 3.8.0
- Implement basic flask-caching to store health status of cookies.canonical.com

## QA

- Check out the staging env https://staging.microk8s.io/
- 


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-31618

